### PR TITLE
feat: add standalone SecureClient with direct HTTP methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,17 +78,18 @@ if err != nil {
 
 ## Advanced Functionality
 
+For direct HTTP access without the OpenAI dependency, use `SecureClient`:
+
 ```go
 // Create a secure client with explicit enclave and repo parameters
-client, err := tinfoil.NewClientWithParams(enclave, repo)
+client, err := tinfoil.NewSecureClient(enclave, repo)
 if err != nil {
 	return fmt.Errorf("Failed to create client: %v", err)
 }
 
-// For direct HTTP access, use the underlying HTTPClient
-httpClient := client.HTTPClient()
+// Make requests directly — TLS is pinned to the verified enclave
 endpoint := fmt.Sprintf("https://%s/health", enclave)
-resp, err := httpClient.Get(endpoint)
+resp, err := client.Get(endpoint)
 if err != nil {
 	return fmt.Errorf("Request failed: %v", err)
 }

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -10,12 +10,6 @@ Make sure you have Go installed, then add the Tinfoil SDK to your project:
 go get github.com/tinfoilsh/tinfoil-go
 ```
 
-Add the required replace directive to your `go.mod`:
-
-```go
-replace github.com/google/go-sev-guest => github.com/tinfoilsh/go-sev-guest v0.0.0-20250704193550-c725e6216008
-```
-
 ## Setup
 
 1. Set your Tinfoil API key as an environment variable:

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -1,0 +1,25 @@
+# HTTP Example
+
+This example demonstrates how to use the Tinfoil Go SDK to make direct HTTP requests to a verified enclave, without using the OpenAI API.
+
+```go
+client, err := tinfoil.NewSecureClient(
+    "inference.tinfoil.sh",
+    "tinfoilsh/confidential-model-router",
+)
+resp, err := client.Get("https://inference.tinfoil.sh/.well-known/tinfoil-metrics")
+```
+
+## Installation
+
+Make sure you have Go installed, then add the Tinfoil SDK to your project:
+
+```bash
+go get github.com/tinfoilsh/tinfoil-go
+```
+
+## Run
+
+```bash
+go run main.go
+```

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+
+	tinfoil "github.com/tinfoilsh/tinfoil-go"
+)
+
+func main() {
+	// Create a secure client pinned to the enclave and source repo.
+	// Attestation is verified automatically during client creation.
+	client, err := tinfoil.NewSecureClient(
+		"inference.tinfoil.sh",
+		"tinfoilsh/confidential-model-router",
+	)
+	if err != nil {
+		log.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Get(), Post(), and Do() use the TLS-pinned HTTP client directly.
+	resp, err := client.Get("https://inference.tinfoil.sh/.well-known/tinfoil-metrics")
+	if err != nil {
+		log.Fatalf("Request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("Failed to read body: %v", err)
+	}
+	fmt.Println(string(body))
+}

--- a/secure_client.go
+++ b/secure_client.go
@@ -1,0 +1,143 @@
+package tinfoil
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/tinfoilsh/verifier/client"
+)
+
+// reVerifyingTransport wraps an http.RoundTripper and automatically re-verifies
+// attestation on certificate errors, handling server certificate rotation.
+type reVerifyingTransport struct {
+	secureClient *client.SecureClient
+	mu           sync.RWMutex
+	transport    http.RoundTripper
+}
+
+func (t *reVerifyingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.mu.RLock()
+	transport := t.transport
+	t.mu.RUnlock()
+
+	resp, err := transport.RoundTrip(req)
+	if err == nil || !isCertificateError(err) {
+		return resp, err
+	}
+
+	// Certificate error detected, reinitialize secure client to re-verify attestation
+	newSecureClient := client.NewSecureClient(t.secureClient.Enclave(), t.secureClient.Repo())
+	newHTTPClient, clientErr := newSecureClient.HTTPClient()
+	if clientErr != nil {
+		// Re-verification failed, connection is genuinely malicious
+		return nil, err
+	}
+
+	// Re-verification succeeded, update transport and retry
+	log.Info("Certificate rotation detected, re-verified attestation successfully")
+
+	t.mu.Lock()
+	t.secureClient = newSecureClient
+	t.transport = newHTTPClient.Transport
+	t.mu.Unlock()
+
+	return newHTTPClient.Transport.RoundTrip(req)
+}
+
+func isCertificateError(err error) bool {
+	var certInvalidErr x509.CertificateInvalidError
+	var unknownAuthErr x509.UnknownAuthorityError
+	var hostnameErr x509.HostnameError
+	var certVerifyErr *tls.CertificateVerificationError
+
+	return errors.Is(err, client.ErrNoTLS) ||
+		errors.Is(err, client.ErrCertMismatch) ||
+		errors.As(err, &certInvalidErr) ||
+		errors.As(err, &unknownAuthErr) ||
+		errors.As(err, &hostnameErr) ||
+		errors.As(err, &certVerifyErr)
+}
+
+// SecureClient provides verified HTTP access to a Tinfoil enclave
+// without any OpenAI dependency.
+type SecureClient struct {
+	verifierClient *client.SecureClient
+	httpClient     *http.Client
+}
+
+// NewSecureClient creates a new SecureClient with explicit enclave and repo parameters.
+func NewSecureClient(enclave, repo string) (*SecureClient, error) {
+	verifierClient := client.NewSecureClient(enclave, repo)
+	return newSecureClientFromVerifier(verifierClient)
+}
+
+// NewDefaultSecureClient creates a new SecureClient using default parameters.
+func NewDefaultSecureClient() (*SecureClient, error) {
+	verifierClient, err := client.NewDefaultClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create secure client: %w", err)
+	}
+	return newSecureClientFromVerifier(verifierClient)
+}
+
+func newSecureClientFromVerifier(verifierClient *client.SecureClient) (*SecureClient, error) {
+	httpClient, err := verifierClient.HTTPClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
+	}
+
+	// Wrap with re-verifying transport to handle certificate rotation
+	reVerifying := &reVerifyingTransport{
+		secureClient: verifierClient,
+		transport:    httpClient.Transport,
+	}
+	httpClient.Transport = reVerifying
+
+	return &SecureClient{
+		verifierClient: verifierClient,
+		httpClient:     httpClient,
+	}, nil
+}
+
+// HTTPClient returns the underlying HTTP client that is configured with
+// automatic certificate re-verification and is restricted to TLS connections
+// to the verified enclave.
+func (sc *SecureClient) HTTPClient() *http.Client {
+	return sc.httpClient
+}
+
+// Enclave returns the enclave hostname.
+func (sc *SecureClient) Enclave() string {
+	return sc.verifierClient.Enclave()
+}
+
+// Repo returns the source repo.
+func (sc *SecureClient) Repo() string {
+	return sc.verifierClient.Repo()
+}
+
+// Verify re-verifies the enclave attestation and returns the ground truth.
+func (sc *SecureClient) Verify() (*client.GroundTruth, error) {
+	return sc.verifierClient.Verify()
+}
+
+// Get issues a GET request to the specified URL using the verified HTTP client.
+func (sc *SecureClient) Get(url string) (*http.Response, error) {
+	return sc.httpClient.Get(url)
+}
+
+// Post issues a POST request to the specified URL using the verified HTTP client.
+func (sc *SecureClient) Post(url, contentType string, body io.Reader) (*http.Response, error) {
+	return sc.httpClient.Post(url, contentType, body)
+}
+
+// Do sends an HTTP request using the verified HTTP client.
+func (sc *SecureClient) Do(req *http.Request) (*http.Response, error) {
+	return sc.httpClient.Do(req)
+}

--- a/secure_client.go
+++ b/secure_client.go
@@ -24,6 +24,7 @@ type reVerifyingTransport struct {
 func (t *reVerifyingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	t.mu.RLock()
 	transport := t.transport
+	secureClient := t.secureClient
 	t.mu.RUnlock()
 
 	resp, err := transport.RoundTrip(req)
@@ -32,7 +33,7 @@ func (t *reVerifyingTransport) RoundTrip(req *http.Request) (*http.Response, err
 	}
 
 	// Certificate error detected, reinitialize secure client to re-verify attestation
-	newSecureClient := client.NewSecureClient(t.secureClient.Enclave(), t.secureClient.Repo())
+	newSecureClient := client.NewSecureClient(secureClient.Enclave(), secureClient.Repo())
 	newHTTPClient, clientErr := newSecureClient.HTTPClient()
 	if clientErr != nil {
 		// Re-verification failed, connection is genuinely malicious

--- a/tinfoil_client.go
+++ b/tinfoil_client.go
@@ -1,141 +1,46 @@
 package tinfoil
 
 import (
-	"crypto/tls"
-	"crypto/x509"
-	"errors"
 	"fmt"
-	"net/http"
-	"sync"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
-	log "github.com/sirupsen/logrus"
-	"github.com/tinfoilsh/verifier/client"
 )
-
-// reVerifyingTransport wraps an http.RoundTripper and automatically re-verifies
-// attestation on certificate errors, handling server certificate rotation.
-type reVerifyingTransport struct {
-	secureClient *client.SecureClient
-	mu           sync.RWMutex
-	transport    http.RoundTripper
-}
-
-func (t *reVerifyingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	t.mu.RLock()
-	transport := t.transport
-	t.mu.RUnlock()
-
-	resp, err := transport.RoundTrip(req)
-	if err == nil || !isCertificateError(err) {
-		return resp, err
-	}
-
-	// Certificate error detected, reinitialize secure client to re-verify attestation
-	newSecureClient := client.NewSecureClient(t.secureClient.Enclave(), t.secureClient.Repo())
-	newHTTPClient, clientErr := newSecureClient.HTTPClient()
-	if clientErr != nil {
-		// Re-verification failed, connection is genuinely malicious
-		return nil, err
-	}
-
-	// Re-verification succeeded, update transport and retry
-	log.Info("Certificate rotation detected, re-verified attestation successfully")
-
-	t.mu.Lock()
-	t.secureClient = newSecureClient
-	t.transport = newHTTPClient.Transport
-	t.mu.Unlock()
-
-	return newHTTPClient.Transport.RoundTrip(req)
-}
-
-func isCertificateError(err error) bool {
-	var certInvalidErr x509.CertificateInvalidError
-	var unknownAuthErr x509.UnknownAuthorityError
-	var hostnameErr x509.HostnameError
-	var certVerifyErr *tls.CertificateVerificationError
-
-	return errors.Is(err, client.ErrNoTLS) ||
-		errors.Is(err, client.ErrCertMismatch) ||
-		errors.As(err, &certInvalidErr) ||
-		errors.As(err, &unknownAuthErr) ||
-		errors.As(err, &hostnameErr) ||
-		errors.As(err, &certVerifyErr)
-}
 
 // Client wraps the OpenAI client to provide secure inference through Tinfoil
 type Client struct {
 	*openai.Client
-	secureClient  *client.SecureClient
-	httpClient    *http.Client
-	enclave, repo string
+	*SecureClient
 }
 
 // NewClientWithParams creates a new secure OpenAI client with explicit enclave and repo parameters
 func NewClientWithParams(enclave, repo string, openaiOpts ...option.RequestOption) (*Client, error) {
-	secureClient := client.NewSecureClient(enclave, repo)
-	return createClientFromSecureClient(secureClient, openaiOpts...)
+	sc, err := NewSecureClient(enclave, repo)
+	if err != nil {
+		return nil, err
+	}
+	return newClientFromSecureClient(sc, openaiOpts...)
 }
 
 // NewClient creates a new secure OpenAI client using default parameters
 func NewClient(openaiOpts ...option.RequestOption) (*Client, error) {
-	secureClient, err := client.NewDefaultClient()
+	sc, err := NewDefaultSecureClient()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create secure client: %w", err)
+		return nil, err
 	}
-	return createClientFromSecureClient(secureClient, openaiOpts...)
+	return newClientFromSecureClient(sc, openaiOpts...)
 }
 
-// createClientFromSecureClient is a helper function to create a Client from a SecureClient
-func createClientFromSecureClient(secureClient *client.SecureClient, openaiOpts ...option.RequestOption) (*Client, error) {
-	// Create an HTTP client with our custom transport
-	httpClient, err := secureClient.HTTPClient()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
-	}
-
-	// Wrap with re-verifying transport to handle certificate rotation
-	reVerifying := &reVerifyingTransport{
-		secureClient: secureClient,
-		transport:    httpClient.Transport,
-	}
-	httpClient.Transport = reVerifying
-
-	// Add our HTTP client and base URL to the options
+// newClientFromSecureClient is a helper function to create a Client from a SecureClient
+func newClientFromSecureClient(sc *SecureClient, openaiOpts ...option.RequestOption) (*Client, error) {
 	allOpts := append(openaiOpts,
-		option.WithHTTPClient(httpClient),
-		option.WithBaseURL(fmt.Sprintf("https://%s/v1/", secureClient.Enclave())),
+		option.WithHTTPClient(sc.HTTPClient()),
+		option.WithBaseURL(fmt.Sprintf("https://%s/v1/", sc.Enclave())),
 	)
 
 	openaiClient := openai.NewClient(allOpts...)
 	return &Client{
 		Client:       &openaiClient,
-		secureClient: secureClient,
-		httpClient:   httpClient,
-		enclave:      secureClient.Enclave(),
-		repo:         secureClient.Repo(),
+		SecureClient: sc,
 	}, nil
-}
-
-func (c *Client) Enclave() string {
-	return c.enclave
-}
-
-func (c *Client) Repo() string {
-	return c.repo
-}
-
-// Verify re-verifies the enclave attestation and returns the ground truth
-func (c *Client) Verify() (*client.GroundTruth, error) {
-	return c.secureClient.Verify()
-}
-
-// HTTPClient returns the underlying HTTP client that is configured with
-// automatic certificate re-verification and is restricted to TLS connections
-// to the verified enclave. This can be used for secure, direct HTTP requests
-// to the enclave.
-func (c *Client) HTTPClient() *http.Client {
-	return c.httpClient
 }

--- a/tinfoil_client_test.go
+++ b/tinfoil_client_test.go
@@ -204,6 +204,19 @@ func TestHTTPClient(t *testing.T) {
 	require.Same(t, httpClient, httpClient2, "HTTPClient() should return the same instance")
 }
 
+func TestNewSecureClient(t *testing.T) {
+	sc, err := NewSecureClient("inference.tinfoil.sh", "tinfoilsh/confidential-model-router")
+	require.NoError(t, err)
+	require.NotNil(t, sc)
+
+	require.Equal(t, "inference.tinfoil.sh", sc.Enclave())
+	require.Equal(t, "tinfoilsh/confidential-model-router", sc.Repo())
+
+	// Verify the transport chain is correctly wired
+	_, ok := sc.HTTPClient().Transport.(*reVerifyingTransport)
+	require.True(t, ok, "SecureClient transport should be reVerifyingTransport")
+}
+
 func TestIsCertificateError(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a standalone SecureClient for direct, TLS‑pinned HTTP access to verified enclaves, and refactors the OpenAI client to compose it. Includes a new HTTP example for raw requests.

- **New Features**
  - Standalone SecureClient (NewSecureClient, NewDefaultSecureClient) with TLS-pinned HTTP and automatic re-verification on cert rotation; includes Get, Post, Do helpers.
  - New direct HTTP example (examples/http) with README and runnable main.go; docs updated to use SecureClient.

- **Bug Fixes**
  - Fixed a data race in reVerifyingTransport when reading/updating SecureClient during certificate rotation.

<sup>Written for commit 55d65a0234ad1b15a004eceb980cb3e8e7992022. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

