### PR TITLE
chore: bump go stdlib patch version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tinfoilsh/tinfoil-go
 
-go 1.25.5
+go 1.25.8
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
Addresses vulnerabilities in net/url and crypto/tls

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Go toolchain/stdlib from 1.25.5 to 1.25.8 to include security fixes in `net/url` and `crypto/tls`. Keeps builds on the latest 1.25 patch and reduces exposure to known vulnerabilities.

<sup>Written for commit 00b2aa5601e52d89ea7b5a057af6a67803badda8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

