### PR TITLE
ci: add govulncheck

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,27 @@
+name: govulncheck
+on:
+  push:
+
+  # The actor associated with the schedule trigger will be the user who last
+  # modified the cron line below or who re-enables the workflow.
+  # See the following resources for more details:
+  # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#actor-for-scheduled-workflows
+  # https://docs.github.com/en/actions/concepts/workflows-and-actions/notifications-for-workflow-runs
+  schedule: # daily at 10:47 UTC
+    - cron: '47 10 * * *'
+
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - run: |
+          go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 -show verbose ./...


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a `govulncheck` CI workflow to scan Go code for vulnerabilities on push, on a daily schedule (10:47 UTC), and via manual runs.
Uses `actions/checkout@v6.0.2` and `actions/setup-go@v6.4.0` (reading `go.mod`) to run `golang.org/x/vuln/cmd/govulncheck@v1.1.4` with verbose output over `./...`.

<sup>Written for commit cf81d900eadcf9929baea416f48ffa4adc7b1fdd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

