### PR TITLE
chore: bump Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tinfoilsh/tinfoil-go
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
Includes fixes for:
GO-2026-4947
GO-2026-4946
GO-2026-4870
GO-2026-4865

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the Go toolchain in `go.mod` from 1.25.8 to 1.25.9 to pick up upstream fixes, addressing GO-2026-4947, GO-2026-4946, GO-2026-4870, and GO-2026-4865.

- **Migration**
  - Ensure your local Go version is 1.25.9 before building.

<sup>Written for commit 7e6747b3745c1e86f42fd0d4128cf819787ca44e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

