### PR TITLE
ci: harden Github workflows

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -12,9 +12,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Set up xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -48,10 +48,7 @@ jobs:
 
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
-        with:
-          files: |
-            Tinfoil.xcframework.zip
-            Tinfoil.xcframework.zip.sha256
-          generate_release_notes: true
-          fail_on_unmatched_files: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: gh release create "$TAG_NAME" --generate-notes Tinfoil.xcframework.zip Tinfoil.xcframework.zip.sha256

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TINFOIL_API_KEY: ${{ secrets.TINFOIL_API_KEY }}
-      TINFOIL_ENCLAVE: ${{ secrets.TINFOIL_ENCLAVE }}
-      TINFOIL_REPO: ${{ secrets.TINFOIL_REPO }}
+      TINFOIL_ENCLAVE: inference.tinfoil.sh
+      TINFOIL_REPO: tinfoilsh/confidential-model-router
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -6,10 +6,14 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       TINFOIL_API_KEY: ${{ secrets.TINFOIL_API_KEY }}
       TINFOIL_ENCLAVE: inference.tinfoil.sh

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -15,7 +15,9 @@ jobs:
       TINFOIL_ENCLAVE: ${{ secrets.TINFOIL_ENCLAVE }}
       TINFOIL_REPO: ${{ secrets.TINFOIL_REPO }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -14,10 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      TINFOIL_API_KEY: ${{ secrets.TINFOIL_API_KEY }}
-      TINFOIL_ENCLAVE: inference.tinfoil.sh
-      TINFOIL_REPO: tinfoilsh/confidential-model-router
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -35,6 +31,10 @@ jobs:
         run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
 
       - name: Run tests
+        env:
+          TINFOIL_API_KEY: ${{ secrets.TINFOIL_API_KEY }}
+          TINFOIL_ENCLAVE: inference.tinfoil.sh
+          TINFOIL_REPO: tinfoilsh/confidential-model-router
         run: |
           set -euo pipefail
           go test -race -p 1 -json -v -covermode atomic -coverprofile=coverage.out ./... 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -28,7 +28,7 @@ jobs:
         run: go build -v ./...
 
       - name: Install gotestfmt
-        run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+        run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@v2.5.0
 
       - name: Run tests
         env:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardens the SDK CI by reducing permissions, scoping secrets, pinning tools, switching releases to the `gh` CLI, and adding a `zizmor` workflow to audit workflow changes. Fixes tests being skipped by defining required enclave/repo variables.

- **Refactors**
  - Bump `actions/checkout` to v6.0.2 with `persist-credentials: false`.
  - Switch releases to `gh release create` with `GH_TOKEN`.
  - Disable Go toolchain cache in release; pin `gotestfmt` to `v2.5.0`.
  - Set `permissions: {}`; limit test job to `contents: read`; move secrets to the test step.
  - Add `zizmor` workflow; pin `zizmorcore/zizmor-action@v0.5.2`.

- **Bug Fixes**
  - Define `TINFOIL_ENCLAVE` and `TINFOIL_REPO` so tests run instead of being silently skipped.

<sup>Written for commit fd2b06aee64135b58ee69efc63e7b1e8fc616a75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

