### PR TITLE
ci: add zizmor check for workflow changes

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,26 @@
+name: zizmor - GitHub Actions security analysis
+
+on:
+  push:
+    branches: ["main"]
+    paths: [".github/workflows/**"]
+  pull_request:
+    branches: ["**"]
+    paths: [".github/workflows/**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false

--- a/README.md
+++ b/README.md
@@ -104,10 +104,6 @@ This library is a drop-in replacement for the [official OpenAI Go client](https:
 
 ## Reporting Vulnerabilities
 
-Please report security vulnerabilities by either:
-
-- Emailing [security@tinfoil.sh](mailto:security@tinfoil.sh)
-
-- Opening an issue on GitHub on this repository
+Please report security vulnerabilities by emailing [security@tinfoil.sh](mailto:security@tinfoil.sh).
 
 We aim to respond to (legitimate) security reports within 24 hours.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a CI workflow that runs zizmor security analysis on GitHub Actions workflow changes for pushes to `main` and all PRs. Also updates the vulnerability reporting policy in the README to email-only.

- **New Features**
  - Runs `zizmorcore/zizmor-action` on Ubuntu.
  - Triggers only on changes under `.github/workflows/**` for `main` pushes and PRs.
  - Uses `actions/checkout` with `persist-credentials: false` and `permissions: {}`.
  - Sets `advanced-security: false` to work without GHAS.

<sup>Written for commit be3a8b71146af1f4629733b3aaacb803ad32c29a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

