### PR TITLE
chore: bump go to 1.25.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tinfoilsh/tinfoil-go
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump the Go toolchain to 1.25.10 to pick up the latest patch fixes and keep builds consistent.
Updates the go directive in go.mod from 1.25.9 to 1.25.10.

<sup>Written for commit 9a426db2d99eb0ac34d727227596098b775c49f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

