### PR TITLE
Add encrypted proxy support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent Notes
+
+## TLS pinning reviews
+
+- Treat TLS pinning as an HTTPS-only property. Plain `http://` requests are not attested TLS connections and should not be reported as certificate-pinning bypasses; only report them when a code path that promises HTTPS fails to reject plaintext.
+- A real TLS pinning bypass is an HTTPS request that can complete without the peer certificate public key matching the attested TLS public-key fingerprint.
+- Review proxy and redirect behavior carefully. In Go, pin checks must run for both direct HTTPS and HTTPS-over-CONNECT proxy connections.
+
+## EHBP bundle reviews
+
+- EHBP request-body security is bound to the attested HPKE key. The bundled enclave certificate carries domain, HPKE, and attestation-hash bindings; it is not expected to be chain-trusted or to prove the attested TLS public key in EHBP mode.

--- a/ehbp_transport.go
+++ b/ehbp_transport.go
@@ -3,6 +3,7 @@ package tinfoil
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"sync"
 
 	"github.com/openai/openai-go/v3/option"
@@ -11,6 +12,10 @@ import (
 	ehbpidentity "github.com/tinfoilsh/encrypted-http-body-protocol/identity"
 	"github.com/tinfoilsh/tinfoil-go/verifier/client"
 )
+
+// enclaveURLHeader tells a proxy which enclave to forward an encrypted request
+// to, so the request reaches the same enclave the client verified.
+const enclaveURLHeader = "X-Tinfoil-Enclave-Url"
 
 // TransportMode selects how the SDK secures traffic to the enclave.
 type TransportMode string
@@ -33,10 +38,12 @@ const (
 )
 
 type clientConfig struct {
-	enclave    string
-	repo       string
-	transport  TransportMode
-	openaiOpts []option.RequestOption
+	enclave              string
+	repo                 string
+	transport            TransportMode
+	baseURL              string
+	attestationBundleURL string
+	openaiOpts           []option.RequestOption
 }
 
 // ClientOption configures a Client created with NewClientWithOptions.
@@ -56,6 +63,24 @@ func WithRepo(repo string) ClientOption {
 // WithTransport selects the transport mode. Defaults to TransportEHBP.
 func WithTransport(mode TransportMode) ClientOption {
 	return func(c *clientConfig) { c.transport = mode }
+}
+
+// WithBaseURL routes requests through the given base URL (for example your own
+// proxy) instead of sending them directly to the enclave. Request bodies stay
+// encrypted end-to-end to the verified enclave; when the base URL's origin
+// differs from the enclave's, the SDK adds the X-Tinfoil-Enclave-Url header so
+// the proxy can forward the encrypted request to the right enclave. Only
+// supported with the EHBP transport.
+func WithBaseURL(baseURL string) ClientOption {
+	return func(c *clientConfig) { c.baseURL = baseURL }
+}
+
+// WithAttestationBundleURL fetches the attestation bundle from the given base
+// URL (for example your own proxy) instead of attesting the enclave directly,
+// so the client only needs to reach a single origin. The bundle is still
+// verified client-side. The enclave host is taken from the verified bundle.
+func WithAttestationBundleURL(attestationBundleURL string) ClientOption {
+	return func(c *clientConfig) { c.attestationBundleURL = attestationBundleURL }
 }
 
 // WithOpenAIOptions appends options passed through to the underlying OpenAI client.
@@ -84,26 +109,32 @@ func NewClientWithOptions(opts ...ClientOption) (*Client, error) {
 	}
 
 	var secureClient *client.SecureClient
-	if cfg.enclave == "" {
+	switch {
+	case cfg.attestationBundleURL != "":
+		// The verified bundle supplies the enclave host, so the router lookup
+		// in NewDefaultClient is unnecessary even when no enclave is set.
+		secureClient = client.NewSecureClient(cfg.enclave, cfg.repo)
+		secureClient.SetAttestationBundleURL(cfg.attestationBundleURL)
+	case cfg.enclave == "":
 		var err error
 		secureClient, err = client.NewDefaultClient()
 		if err != nil {
 			return nil, fmt.Errorf("failed to create secure client: %w", err)
 		}
-	} else {
+	default:
 		secureClient = client.NewSecureClient(cfg.enclave, cfg.repo)
 	}
 
-	return createClientFromSecureClient(secureClient, cfg.transport, cfg.openaiOpts...)
+	return createClientFromSecureClient(secureClient, cfg.transport, cfg.baseURL, cfg.openaiOpts...)
 }
 
 // secureHTTPClient builds an *http.Client for the requested transport mode.
-func secureHTTPClient(secureClient *client.SecureClient, mode TransportMode) (*http.Client, error) {
+func secureHTTPClient(secureClient *client.SecureClient, mode TransportMode, baseURL string) (*http.Client, error) {
 	switch mode {
 	case TransportTLS:
 		return tlsPinnedHTTPClient(secureClient)
 	case TransportEHBP, "":
-		return ehbpHTTPClient(secureClient)
+		return ehbpHTTPClient(secureClient, baseURL)
 	default:
 		return nil, fmt.Errorf("unknown transport mode: %q", mode)
 	}
@@ -127,8 +158,10 @@ func tlsPinnedHTTPClient(secureClient *client.SecureClient) (*http.Client, error
 
 // ehbpHTTPClient returns an HTTP client whose request bodies are encrypted to
 // the enclave's attested HPKE public key and that re-verifies attestation when
-// the server rotates its HPKE key.
-func ehbpHTTPClient(secureClient *client.SecureClient) (*http.Client, error) {
+// the server rotates its HPKE key. When baseURL routes requests through a proxy
+// whose origin differs from the enclave's, the client adds the
+// X-Tinfoil-Enclave-Url header so the proxy can forward to the verified enclave.
+func ehbpHTTPClient(secureClient *client.SecureClient, baseURL string) (*http.Client, error) {
 	groundTruth := secureClient.GroundTruth()
 	if groundTruth == nil {
 		var err error
@@ -143,9 +176,62 @@ func ehbpHTTPClient(secureClient *client.SecureClient) (*http.Client, error) {
 		return nil, err
 	}
 
+	var transport http.RoundTripper = newEHBPReVerifyingTransport(secureClient, inner)
+	if headerValue, ok := enclaveURLHeaderValue(baseURL, secureClient.Enclave()); ok {
+		transport = &enclaveURLHeaderTransport{enclaveURL: headerValue, transport: transport}
+	}
+
 	return &http.Client{
-		Transport: newEHBPReVerifyingTransport(secureClient, inner),
+		Transport: transport,
 	}, nil
+}
+
+// enclaveURLHeaderValue returns the X-Tinfoil-Enclave-Url header value and
+// whether it should be injected. The header is only needed when requests are
+// routed through a proxy whose origin differs from the verified enclave's.
+func enclaveURLHeaderValue(baseURL, enclave string) (string, bool) {
+	if baseURL == "" || enclave == "" {
+		return "", false
+	}
+	enclaveURL := "https://" + enclave
+	proxyOrigin, err := originOf(baseURL)
+	if err != nil {
+		return "", false
+	}
+	enclaveOrigin, err := originOf(enclaveURL)
+	if err != nil {
+		return "", false
+	}
+	if proxyOrigin == enclaveOrigin {
+		return "", false
+	}
+	return enclaveURL, true
+}
+
+func originOf(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("missing host in URL %q", rawURL)
+	}
+	return u.Scheme + "://" + u.Host, nil
+}
+
+// enclaveURLHeaderTransport injects the X-Tinfoil-Enclave-Url header before
+// delegating to the wrapped transport. EHBP leaves request headers in
+// plaintext, so the header reaches the proxy while the body stays sealed to the
+// enclave's HPKE key.
+type enclaveURLHeaderTransport struct {
+	enclaveURL string
+	transport  http.RoundTripper
+}
+
+func (t *enclaveURLHeaderTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set(enclaveURLHeader, t.enclaveURL)
+	return t.transport.RoundTrip(req)
 }
 
 // buildEHBPTransport creates an EHBP round tripper bound to a hex-encoded HPKE

--- a/ehbp_transport.go
+++ b/ehbp_transport.go
@@ -107,6 +107,11 @@ func NewClientWithOptions(opts ...ClientOption) (*Client, error) {
 	if cfg.repo == "" {
 		cfg.repo = defaultConfigRepo
 	}
+	// Routing through a proxy base URL relies on EHBP sealing the body to the
+	// enclave; TLS certificate pinning would reject the proxy's certificate.
+	if cfg.baseURL != "" && cfg.transport == TransportTLS {
+		return nil, fmt.Errorf("WithBaseURL is only supported with the EHBP transport")
+	}
 
 	var secureClient *client.SecureClient
 	switch {

--- a/ehbp_transport.go
+++ b/ehbp_transport.go
@@ -247,8 +247,15 @@ func ehbpHTTPClient(secureClient *client.SecureClient, baseURL string) (*http.Cl
 	}
 
 	var transport http.RoundTripper = newEHBPReVerifyingTransport(secureClient, inner)
-	if headerValue, ok := enclaveURLHeaderValue(baseURL, secureClient.Enclave()); ok {
-		transport = &enclaveURLHeaderTransport{enclaveURL: headerValue, transport: transport}
+	// With a proxy base URL, recompute the header per request from the client's
+	// current enclave so it stays correct after a re-verification swaps in a
+	// different enclave (for example when attesting from a bundle).
+	if baseURL != "" {
+		transport = &enclaveURLHeaderTransport{
+			enclave:   secureClient,
+			baseURL:   baseURL,
+			transport: transport,
+		}
 	}
 
 	return &http.Client{
@@ -293,14 +300,24 @@ func originOf(rawURL string) (string, error) {
 // delegating to the wrapped transport. EHBP leaves request headers in
 // plaintext, so the header reaches the proxy while the body stays sealed to the
 // enclave's HPKE key.
+// enclaveSource provides the currently verified enclave host. *client.SecureClient
+// satisfies it; the header transport reads it per request so the value follows a
+// re-verification that swaps in a different enclave.
+type enclaveSource interface {
+	Enclave() string
+}
+
 type enclaveURLHeaderTransport struct {
-	enclaveURL string
-	transport  http.RoundTripper
+	enclave   enclaveSource
+	baseURL   string
+	transport http.RoundTripper
 }
 
 func (t *enclaveURLHeaderTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
-	req.Header.Set(enclaveURLHeader, t.enclaveURL)
+	if headerValue, ok := enclaveURLHeaderValue(t.baseURL, t.enclave.Enclave()); ok {
+		req.Header.Set(enclaveURLHeader, headerValue)
+	}
 	return t.transport.RoundTrip(req)
 }
 

--- a/ehbp_transport.go
+++ b/ehbp_transport.go
@@ -241,25 +241,33 @@ func ehbpHTTPClient(secureClient *client.SecureClient, baseURL string) (*http.Cl
 		}
 	}
 
-	inner, err := buildEHBPTransport(groundTruth.HPKEPublicKey)
+	// buildTransport builds an EHBP transport for an attested HPKE key, wrapping
+	// it with the enclave-URL header when requests route through a proxy. The
+	// enclave host is captured here rather than read per request: re-verification
+	// rebuilds the transport with the then-current enclave, which keeps the
+	// header correct (including on the retry that follows a key rotation) without
+	// an unsynchronized read of the client's mutable state.
+	buildTransport := func(hpkePublicKeyHex string) (http.RoundTripper, error) {
+		inner, err := buildEHBPTransport(hpkePublicKeyHex)
+		if err != nil {
+			return nil, err
+		}
+		if headerValue, ok := enclaveURLHeaderValue(baseURL, secureClient.Enclave()); ok {
+			return &enclaveURLHeaderTransport{
+				enclaveURL: headerValue,
+				transport:  inner,
+			}, nil
+		}
+		return inner, nil
+	}
+
+	inner, err := buildTransport(groundTruth.HPKEPublicKey)
 	if err != nil {
 		return nil, err
 	}
 
-	var transport http.RoundTripper = newEHBPReVerifyingTransport(secureClient, inner)
-	// With a proxy base URL, recompute the header per request from the client's
-	// current enclave so it stays correct after a re-verification swaps in a
-	// different enclave (for example when attesting from a bundle).
-	if baseURL != "" {
-		transport = &enclaveURLHeaderTransport{
-			enclave:   secureClient,
-			baseURL:   baseURL,
-			transport: transport,
-		}
-	}
-
 	return &http.Client{
-		Transport: transport,
+		Transport: newEHBPReVerifyingTransport(secureClient, inner, buildTransport),
 	}, nil
 }
 
@@ -299,25 +307,17 @@ func originOf(rawURL string) (string, error) {
 // enclaveURLHeaderTransport injects the X-Tinfoil-Enclave-Url header before
 // delegating to the wrapped transport. EHBP leaves request headers in
 // plaintext, so the header reaches the proxy while the body stays sealed to the
-// enclave's HPKE key.
-// enclaveSource provides the currently verified enclave host. *client.SecureClient
-// satisfies it; the header transport reads it per request so the value follows a
-// re-verification that swaps in a different enclave.
-type enclaveSource interface {
-	Enclave() string
-}
-
+// enclave's HPKE key. The value is captured when the transport is built; a
+// re-verification that swaps in a different enclave rebuilds this transport with
+// the new value, which also keeps every retry pointed at the right enclave.
 type enclaveURLHeaderTransport struct {
-	enclave   enclaveSource
-	baseURL   string
-	transport http.RoundTripper
+	enclaveURL string
+	transport  http.RoundTripper
 }
 
 func (t *enclaveURLHeaderTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
-	if headerValue, ok := enclaveURLHeaderValue(t.baseURL, t.enclave.Enclave()); ok {
-		req.Header.Set(enclaveURLHeader, headerValue)
-	}
+	req.Header.Set(enclaveURLHeader, t.enclaveURL)
 	return t.transport.RoundTrip(req)
 }
 
@@ -359,7 +359,7 @@ type ehbpReVerifyingTransport struct {
 	reverify func() (http.RoundTripper, error)
 }
 
-func newEHBPReVerifyingTransport(secureClient *client.SecureClient, inner http.RoundTripper) *ehbpReVerifyingTransport {
+func newEHBPReVerifyingTransport(secureClient *client.SecureClient, inner http.RoundTripper, build func(hpkePublicKeyHex string) (http.RoundTripper, error)) *ehbpReVerifyingTransport {
 	return &ehbpReVerifyingTransport{
 		transport: inner,
 		reverify: func() (http.RoundTripper, error) {
@@ -367,7 +367,7 @@ func newEHBPReVerifyingTransport(secureClient *client.SecureClient, inner http.R
 			if err != nil {
 				return nil, err
 			}
-			return buildEHBPTransport(groundTruth.HPKEPublicKey)
+			return build(groundTruth.HPKEPublicKey)
 		},
 	}
 }

--- a/ehbp_transport.go
+++ b/ehbp_transport.go
@@ -129,15 +129,80 @@ func NewClientWithOptions(opts ...ClientOption) (*Client, error) {
 }
 
 // secureHTTPClient builds an *http.Client for the requested transport mode.
+//
+// The returned client is bound to the verified enclave (and the configured
+// proxy, if any): neither EHBP nor TLS pinning encrypts request headers, which
+// may carry the API key, so requests to any other host or over plain http are
+// refused.
 func secureHTTPClient(secureClient *client.SecureClient, mode TransportMode, baseURL string) (*http.Client, error) {
+	var (
+		httpClient *http.Client
+		err        error
+	)
 	switch mode {
 	case TransportTLS:
-		return tlsPinnedHTTPClient(secureClient)
+		httpClient, err = tlsPinnedHTTPClient(secureClient)
 	case TransportEHBP, "":
-		return ehbpHTTPClient(secureClient, baseURL)
+		httpClient, err = ehbpHTTPClient(secureClient, baseURL)
 	default:
 		return nil, fmt.Errorf("unknown transport mode: %q", mode)
 	}
+	if err != nil {
+		return nil, err
+	}
+
+	origins, err := allowedOrigins(secureClient.Enclave(), baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine allowed request origins: %w", err)
+	}
+	httpClient.Transport = &hostBoundRoundTripper{
+		allowedOrigins: origins,
+		enclave:        secureClient.Enclave(),
+		transport:      httpClient.Transport,
+	}
+	return httpClient, nil
+}
+
+// allowedOrigins returns the set of origins a secured request may target: the
+// verified enclave and, when set, the proxy base URL.
+func allowedOrigins(enclave, baseURL string) (map[string]struct{}, error) {
+	origins := make(map[string]struct{}, 2)
+	if enclave != "" {
+		origin, err := originOf("https://" + enclave)
+		if err != nil {
+			return nil, err
+		}
+		origins[origin] = struct{}{}
+	}
+	if baseURL != "" {
+		origin, err := originOf(baseURL)
+		if err != nil {
+			return nil, err
+		}
+		origins[origin] = struct{}{}
+	}
+	return origins, nil
+}
+
+// hostBoundRoundTripper rejects requests to any origin other than the verified
+// enclave or the configured proxy, and refuses non-https requests. This guards
+// the escape-hatch HTTP client (and the OpenAI client) from leaking plaintext
+// request headers, such as the API key, to an arbitrary host.
+type hostBoundRoundTripper struct {
+	allowedOrigins map[string]struct{}
+	enclave        string
+	transport      http.RoundTripper
+}
+
+func (t *hostBoundRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Scheme != "https" {
+		return nil, fmt.Errorf("refusing to send request over non-https URL %q", req.URL.String())
+	}
+	origin := req.URL.Scheme + "://" + req.URL.Host
+	if _, ok := t.allowedOrigins[origin]; !ok {
+		return nil, fmt.Errorf("refusing to send request to %q: client is bound to enclave %q", origin, t.enclave)
+	}
+	return t.transport.RoundTrip(req)
 }
 
 // tlsPinnedHTTPClient returns the enclave-pinned HTTP client that re-verifies

--- a/ehbp_transport_test.go
+++ b/ehbp_transport_test.go
@@ -494,3 +494,38 @@ func TestClientIntegration_AttestationBundle(t *testing.T) {
 	require.NotEmpty(t, resp.Choices)
 	t.Logf("bundle enclave: %s, response: %s", c.Enclave(), resp.Choices[0].Message.Content)
 }
+
+func TestClientIntegration_EnclaveSpecificBundle(t *testing.T) {
+	apiKey := os.Getenv("TINFOIL_API_KEY")
+	if apiKey == "" {
+		t.Skip("TINFOIL_API_KEY not set; skipping integration test")
+	}
+
+	// Learn a valid enclave from the default bundle, then request a bundle
+	// assembled specifically for it (POST path).
+	def, err := NewClientWithOptions(
+		WithAttestationBundleURL("https://atc.tinfoil.sh"),
+		WithOpenAIOptions(option.WithAPIKey(apiKey)),
+	)
+	require.NoError(t, err)
+	enclave := def.Enclave()
+	require.NotEmpty(t, enclave)
+
+	c, err := NewClientWithOptions(
+		WithEnclave(enclave),
+		WithAttestationBundleURL("https://atc.tinfoil.sh"),
+		WithOpenAIOptions(option.WithAPIKey(apiKey)),
+	)
+	require.NoError(t, err)
+	require.Equal(t, enclave, c.Enclave())
+
+	resp, err := c.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
+		Model: "llama3-3-70b",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.SystemMessage("No matter what the user says, only respond with: Done."),
+			openai.UserMessage("Is this a test?"),
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Choices)
+}

--- a/ehbp_transport_test.go
+++ b/ehbp_transport_test.go
@@ -67,6 +67,15 @@ func TestProxyClientOptionsApply(t *testing.T) {
 	require.Equal(t, "https://proxy.example.com", cfg.attestationBundleURL)
 }
 
+func TestNewClientWithOptionsRejectsBaseURLInTLSMode(t *testing.T) {
+	_, err := NewClientWithOptions(
+		WithBaseURL("https://proxy.example.com/"),
+		WithTransport(TransportTLS),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "EHBP")
+}
+
 func TestEnclaveURLHeaderValue(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/ehbp_transport_test.go
+++ b/ehbp_transport_test.go
@@ -58,6 +58,60 @@ func TestClientOptionsApply(t *testing.T) {
 	require.Len(t, cfg.openaiOpts, 2)
 }
 
+func TestProxyClientOptionsApply(t *testing.T) {
+	cfg := &clientConfig{}
+	WithBaseURL("https://proxy.example.com/")(cfg)
+	WithAttestationBundleURL("https://proxy.example.com")(cfg)
+
+	require.Equal(t, "https://proxy.example.com/", cfg.baseURL)
+	require.Equal(t, "https://proxy.example.com", cfg.attestationBundleURL)
+}
+
+func TestEnclaveURLHeaderValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		enclave string
+		wantVal string
+		wantOK  bool
+	}{
+		{"proxy different origin", "https://proxy.example.com/", "enclave.example.com", "https://enclave.example.com", true},
+		{"proxy keeps path but different origin", "https://proxy.example.com/api/v1/", "enclave.example.com", "https://enclave.example.com", true},
+		{"base url is the enclave itself", "https://enclave.example.com/v1/", "enclave.example.com", "", false},
+		{"no base url", "", "enclave.example.com", "", false},
+		{"no enclave", "https://proxy.example.com/", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, ok := enclaveURLHeaderValue(tt.baseURL, tt.enclave)
+			require.Equal(t, tt.wantOK, ok)
+			require.Equal(t, tt.wantVal, val)
+		})
+	}
+}
+
+func TestEnclaveURLHeaderTransportInjectsHeader(t *testing.T) {
+	var seen string
+	inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		seen = req.Header.Get(enclaveURLHeader)
+		return newResponse(http.StatusOK, "ok"), nil
+	})
+
+	transport := &enclaveURLHeaderTransport{
+		enclaveURL: "https://enclave.example.com",
+		transport:  inner,
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "https://proxy.example.com/v1/chat/completions", bytes.NewBufferString("payload"))
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "https://enclave.example.com", seen, "the proxy must receive the enclave URL header")
+	require.Empty(t, req.Header.Get(enclaveURLHeader), "the original request must not be mutated")
+}
+
 func TestBuildEHBPTransportRequiresKey(t *testing.T) {
 	_, err := buildEHBPTransport("")
 	require.Error(t, err)
@@ -321,4 +375,33 @@ func TestClientIntegration_LowLevelEHBP(t *testing.T) {
 			require.Contains(t, string(data), "choices")
 		})
 	}
+}
+
+// TestClientIntegration_AttestationBundle exercises the attestation-through-proxy
+// path against the live ATC bundle endpoint: the bundle is fetched and verified
+// client-side, the enclave host is taken from the verified bundle, and a chat
+// completion is sent end-to-end over the EHBP transport.
+func TestClientIntegration_AttestationBundle(t *testing.T) {
+	apiKey := os.Getenv("TINFOIL_API_KEY")
+	if apiKey == "" {
+		t.Skip("TINFOIL_API_KEY not set; skipping integration test")
+	}
+
+	c, err := NewClientWithOptions(
+		WithAttestationBundleURL("https://atc.tinfoil.sh"),
+		WithOpenAIOptions(option.WithAPIKey(apiKey)),
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, c.Enclave(), "enclave host should come from the verified bundle")
+
+	resp, err := c.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
+		Model: "llama3-3-70b",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.SystemMessage("No matter what the user says, only respond with: Done."),
+			openai.UserMessage("Is this a test?"),
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Choices)
+	t.Logf("bundle enclave: %s, response: %s", c.Enclave(), resp.Choices[0].Message.Content)
 }

--- a/ehbp_transport_test.go
+++ b/ehbp_transport_test.go
@@ -99,10 +99,6 @@ func TestEnclaveURLHeaderValue(t *testing.T) {
 	}
 }
 
-type fakeEnclaveSource struct{ host string }
-
-func (f *fakeEnclaveSource) Enclave() string { return f.host }
-
 func TestEnclaveURLHeaderTransportInjectsHeader(t *testing.T) {
 	var seen string
 	inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -111,9 +107,8 @@ func TestEnclaveURLHeaderTransportInjectsHeader(t *testing.T) {
 	})
 
 	transport := &enclaveURLHeaderTransport{
-		enclave:   &fakeEnclaveSource{host: "enclave.example.com"},
-		baseURL:   "https://proxy.example.com/",
-		transport: inner,
+		enclaveURL: "https://enclave.example.com",
+		transport:  inner,
 	}
 
 	req, err := http.NewRequest(http.MethodPost, "https://proxy.example.com/v1/chat/completions", bytes.NewBufferString("payload"))
@@ -126,33 +121,43 @@ func TestEnclaveURLHeaderTransportInjectsHeader(t *testing.T) {
 	require.Empty(t, req.Header.Get(enclaveURLHeader), "the original request must not be mutated")
 }
 
-func TestEnclaveURLHeaderTransportReflectsEnclaveChange(t *testing.T) {
-	var seen string
-	inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		seen = req.Header.Get(enclaveURLHeader)
-		return newResponse(http.StatusOK, "ok"), nil
+// TestEHBPReVerifyingTransportRefreshesEnclaveHeaderOnRotation verifies that
+// after a key rotation triggers re-verification, the retried request carries the
+// header for the newly verified enclave rather than a stale one. The header
+// transport is the inner layer that reverify rebuilds, so the retry flows
+// through the refreshed value.
+func TestEHBPReVerifyingTransportRefreshesEnclaveHeaderOnRotation(t *testing.T) {
+	keyErr := ehbpidentity.NewKeyConfigError(fmt.Errorf("key configuration mismatch"))
+
+	var firstHeader, retryHeader string
+	firstInner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		firstHeader = req.Header.Get(enclaveURLHeader)
+		return nil, keyErr
+	})
+	secondInner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		retryHeader = req.Header.Get(enclaveURLHeader)
+		return newResponse(http.StatusOK, "recovered"), nil
 	})
 
-	source := &fakeEnclaveSource{host: "old.example.com"}
-	transport := &enclaveURLHeaderTransport{
-		enclave:   source,
-		baseURL:   "https://proxy.example.com/",
-		transport: inner,
+	first := &enclaveURLHeaderTransport{enclaveURL: "https://old.example.com", transport: firstInner}
+	second := &enclaveURLHeaderTransport{enclaveURL: "https://new.example.com", transport: secondInner}
+
+	transport := &ehbpReVerifyingTransport{transport: first}
+	transport.reverify = func() (http.RoundTripper, error) {
+		transport.mu.Lock()
+		transport.transport = second
+		transport.mu.Unlock()
+		return second, nil
 	}
 
-	req, err := http.NewRequest(http.MethodPost, "https://proxy.example.com/v1/x", bytes.NewBufferString("p"))
+	req, err := http.NewRequest(http.MethodPost, "https://proxy.example.com/v1/x", bytes.NewBufferString("payload"))
 	require.NoError(t, err)
-	_, err = transport.RoundTrip(req)
-	require.NoError(t, err)
-	require.Equal(t, "https://old.example.com", seen)
 
-	// A re-verification may swap in a different enclave; the header must follow.
-	source.host = "new.example.com"
-	req, err = http.NewRequest(http.MethodPost, "https://proxy.example.com/v1/x", bytes.NewBufferString("p"))
+	resp, err := transport.RoundTrip(req)
 	require.NoError(t, err)
-	_, err = transport.RoundTrip(req)
-	require.NoError(t, err)
-	require.Equal(t, "https://new.example.com", seen)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "https://old.example.com", firstHeader, "first attempt carries the original enclave header")
+	require.Equal(t, "https://new.example.com", retryHeader, "retry must carry the refreshed enclave header after re-verification")
 }
 
 func TestHostBoundRoundTripperAllowsEnclaveAndProxy(t *testing.T) {

--- a/ehbp_transport_test.go
+++ b/ehbp_transport_test.go
@@ -99,6 +99,10 @@ func TestEnclaveURLHeaderValue(t *testing.T) {
 	}
 }
 
+type fakeEnclaveSource struct{ host string }
+
+func (f *fakeEnclaveSource) Enclave() string { return f.host }
+
 func TestEnclaveURLHeaderTransportInjectsHeader(t *testing.T) {
 	var seen string
 	inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -107,8 +111,9 @@ func TestEnclaveURLHeaderTransportInjectsHeader(t *testing.T) {
 	})
 
 	transport := &enclaveURLHeaderTransport{
-		enclaveURL: "https://enclave.example.com",
-		transport:  inner,
+		enclave:   &fakeEnclaveSource{host: "enclave.example.com"},
+		baseURL:   "https://proxy.example.com/",
+		transport: inner,
 	}
 
 	req, err := http.NewRequest(http.MethodPost, "https://proxy.example.com/v1/chat/completions", bytes.NewBufferString("payload"))
@@ -119,6 +124,35 @@ func TestEnclaveURLHeaderTransportInjectsHeader(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.Equal(t, "https://enclave.example.com", seen, "the proxy must receive the enclave URL header")
 	require.Empty(t, req.Header.Get(enclaveURLHeader), "the original request must not be mutated")
+}
+
+func TestEnclaveURLHeaderTransportReflectsEnclaveChange(t *testing.T) {
+	var seen string
+	inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		seen = req.Header.Get(enclaveURLHeader)
+		return newResponse(http.StatusOK, "ok"), nil
+	})
+
+	source := &fakeEnclaveSource{host: "old.example.com"}
+	transport := &enclaveURLHeaderTransport{
+		enclave:   source,
+		baseURL:   "https://proxy.example.com/",
+		transport: inner,
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "https://proxy.example.com/v1/x", bytes.NewBufferString("p"))
+	require.NoError(t, err)
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, "https://old.example.com", seen)
+
+	// A re-verification may swap in a different enclave; the header must follow.
+	source.host = "new.example.com"
+	req, err = http.NewRequest(http.MethodPost, "https://proxy.example.com/v1/x", bytes.NewBufferString("p"))
+	require.NoError(t, err)
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, "https://new.example.com", seen)
 }
 
 func TestHostBoundRoundTripperAllowsEnclaveAndProxy(t *testing.T) {

--- a/ehbp_transport_test.go
+++ b/ehbp_transport_test.go
@@ -112,6 +112,52 @@ func TestEnclaveURLHeaderTransportInjectsHeader(t *testing.T) {
 	require.Empty(t, req.Header.Get(enclaveURLHeader), "the original request must not be mutated")
 }
 
+func TestHostBoundRoundTripperAllowsEnclaveAndProxy(t *testing.T) {
+	origins, err := allowedOrigins("enclave.example.com", "https://proxy.example.com/v1/")
+	require.NoError(t, err)
+
+	var calls int
+	inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		return newResponse(http.StatusOK, "ok"), nil
+	})
+	rt := &hostBoundRoundTripper{allowedOrigins: origins, enclave: "enclave.example.com", transport: inner}
+
+	for _, target := range []string{
+		"https://enclave.example.com/v1/models",
+		"https://proxy.example.com/v1/chat/completions",
+	} {
+		req, err := http.NewRequest(http.MethodGet, target, nil)
+		require.NoError(t, err)
+		resp, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+	require.Equal(t, 2, calls)
+}
+
+func TestHostBoundRoundTripperRejectsForeignHostAndScheme(t *testing.T) {
+	origins, err := allowedOrigins("enclave.example.com", "")
+	require.NoError(t, err)
+	inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("inner transport must not be called for a rejected request")
+		return nil, nil
+	})
+	rt := &hostBoundRoundTripper{allowedOrigins: origins, enclave: "enclave.example.com", transport: inner}
+
+	foreign, err := http.NewRequest(http.MethodGet, "https://evil.example.com/v1/models", nil)
+	require.NoError(t, err)
+	_, err = rt.RoundTrip(foreign)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "evil.example.com")
+
+	plaintext, err := http.NewRequest(http.MethodGet, "http://enclave.example.com/v1/models", nil)
+	require.NoError(t, err)
+	_, err = rt.RoundTrip(plaintext)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "non-https")
+}
+
 func TestBuildEHBPTransportRequiresKey(t *testing.T) {
 	_, err := buildEHBPTransport("")
 	require.Error(t, err)

--- a/tinfoil_client.go
+++ b/tinfoil_client.go
@@ -138,9 +138,11 @@ func (c *Client) Verify() (*client.GroundTruth, error) {
 	return c.secureClient.Verify()
 }
 
-// HTTPClient returns the underlying HTTP client that is configured with
-// automatic certificate re-verification and is restricted to TLS connections
-// to the verified enclave. This can be used for secure, direct HTTP requests
+// HTTPClient returns the underlying HTTP client used to reach the enclave. It
+// re-verifies attestation automatically when the enclave rotates its key, and
+// it is bound to the verified enclave (and the configured proxy, if any):
+// requests to any other host, or over plain http, are refused because request
+// headers are not encrypted. This can be used for secure, direct HTTP requests
 // to the enclave.
 func (c *Client) HTTPClient() *http.Client {
 	return c.httpClient

--- a/tinfoil_client.go
+++ b/tinfoil_client.go
@@ -77,7 +77,7 @@ type Client struct {
 // NewClientWithParams creates a new secure OpenAI client with explicit enclave and repo parameters
 func NewClientWithParams(enclave, repo string, openaiOpts ...option.RequestOption) (*Client, error) {
 	secureClient := client.NewSecureClient(enclave, repo)
-	return createClientFromSecureClient(secureClient, defaultTransportMode, openaiOpts...)
+	return createClientFromSecureClient(secureClient, defaultTransportMode, "", openaiOpts...)
 }
 
 // NewClient creates a new secure OpenAI client using default parameters
@@ -86,20 +86,27 @@ func NewClient(openaiOpts ...option.RequestOption) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create secure client: %w", err)
 	}
-	return createClientFromSecureClient(secureClient, defaultTransportMode, openaiOpts...)
+	return createClientFromSecureClient(secureClient, defaultTransportMode, "", openaiOpts...)
 }
 
 // createClientFromSecureClient is a helper function to create a Client from a SecureClient
-func createClientFromSecureClient(secureClient *client.SecureClient, mode TransportMode, openaiOpts ...option.RequestOption) (*Client, error) {
-	httpClient, err := secureHTTPClient(secureClient, mode)
+func createClientFromSecureClient(secureClient *client.SecureClient, mode TransportMode, baseURL string, openaiOpts ...option.RequestOption) (*Client, error) {
+	httpClient, err := secureHTTPClient(secureClient, mode, baseURL)
 	if err != nil {
 		return nil, err
+	}
+
+	// Route requests through the proxy base URL when set, otherwise straight to
+	// the verified enclave.
+	resolvedBaseURL := baseURL
+	if resolvedBaseURL == "" {
+		resolvedBaseURL = fmt.Sprintf("https://%s/v1/", secureClient.Enclave())
 	}
 
 	// Add our HTTP client and base URL to the options
 	allOpts := append(openaiOpts,
 		option.WithHTTPClient(httpClient),
-		option.WithBaseURL(fmt.Sprintf("https://%s/v1/", secureClient.Enclave())),
+		option.WithBaseURL(resolvedBaseURL),
 	)
 
 	openaiClient := openai.NewClient(allOpts...)

--- a/tinfoil_client_test.go
+++ b/tinfoil_client_test.go
@@ -195,9 +195,12 @@ func TestHTTPClient(t *testing.T) {
 	httpClient := client.HTTPClient()
 	require.NotNil(t, httpClient, "HTTPClient() should return a non-nil client")
 
-	// Verify the transport is the EHBP re-verifying transport (the default mode)
-	_, ok := httpClient.Transport.(*ehbpReVerifyingTransport)
-	require.True(t, ok, "HTTPClient transport should be ehbpReVerifyingTransport")
+	// The outermost transport binds requests to the enclave/proxy host; the
+	// EHBP re-verifying transport (the default mode) sits inside it.
+	hostBound, ok := httpClient.Transport.(*hostBoundRoundTripper)
+	require.True(t, ok, "HTTPClient transport should be hostBoundRoundTripper")
+	_, ok = hostBound.transport.(*ehbpReVerifyingTransport)
+	require.True(t, ok, "inner transport should be ehbpReVerifyingTransport")
 
 	// Verify it returns the same instance (shared client)
 	httpClient2 := client.HTTPClient()

--- a/verifier/attestation/attestation.go
+++ b/verifier/attestation/attestation.go
@@ -342,6 +342,16 @@ func FetchBundle() (*Bundle, error) {
 
 // FetchBundleFrom retrieves a complete attestation bundle from a custom base URL
 func FetchBundleFrom(attestationBundleURL string) (*Bundle, error) {
+	// The bundle is the entire trust root for verification; fetching it over a
+	// plaintext connection would let an attacker substitute it (MITM).
+	u, err := url.Parse(attestationBundleURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid attestation bundle URL %q: %v", attestationBundleURL, err)
+	}
+	if u.Scheme != "https" {
+		return nil, fmt.Errorf("attestation bundle URL must use https; got %q", attestationBundleURL)
+	}
+
 	bundleURL := attestationBundleURL + "/attestation"
 
 	resp, _, err := util.Get(bundleURL)

--- a/verifier/attestation/attestation.go
+++ b/verifier/attestation/attestation.go
@@ -340,8 +340,21 @@ func FetchBundle() (*Bundle, error) {
 	return FetchBundleFrom(defaultAttestationBundleURL)
 }
 
-// FetchBundleFrom retrieves a complete attestation bundle from a custom base URL
+type bundleRequest struct {
+	EnclaveURL string `json:"enclaveUrl,omitempty"`
+	Repo       string `json:"repo,omitempty"`
+}
+
+// FetchBundleFrom retrieves the default attestation bundle from a custom base URL.
 func FetchBundleFrom(attestationBundleURL string) (*Bundle, error) {
+	return FetchBundleFor(attestationBundleURL, "", "")
+}
+
+// FetchBundleFor retrieves an attestation bundle from a custom base URL. When an
+// enclave URL or a code repository is supplied, it asks the bundle service to
+// assemble a bundle for that specific enclave/repo (via POST) instead of
+// returning the default router bundle (GET).
+func FetchBundleFor(attestationBundleURL, enclaveURL, repo string) (*Bundle, error) {
 	// The bundle is the entire trust root for verification; fetching it over a
 	// plaintext connection would let an attacker substitute it (MITM).
 	u, err := url.Parse(attestationBundleURL)
@@ -354,7 +367,16 @@ func FetchBundleFrom(attestationBundleURL string) (*Bundle, error) {
 
 	bundleURL := attestationBundleURL + "/attestation"
 
-	resp, _, err := util.Get(bundleURL)
+	var resp []byte
+	if enclaveURL != "" || repo != "" {
+		reqBody, marshalErr := json.Marshal(bundleRequest{EnclaveURL: enclaveURL, Repo: repo})
+		if marshalErr != nil {
+			return nil, fmt.Errorf("failed to encode bundle request: %v", marshalErr)
+		}
+		resp, _, err = util.Post(bundleURL, "application/json", reqBody)
+	} else {
+		resp, _, err = util.Get(bundleURL)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch bundle: %v", err)
 	}

--- a/verifier/attestation/attestation_test.go
+++ b/verifier/attestation/attestation_test.go
@@ -185,3 +185,9 @@ func TestAttestationFingerprint(t *testing.T) {
 		})
 	}
 }
+
+func TestFetchBundleFromRejectsNonHTTPS(t *testing.T) {
+	_, err := FetchBundleFrom("http://atc.example")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "https")
+}

--- a/verifier/attestation/attestation_test.go
+++ b/verifier/attestation/attestation_test.go
@@ -1,6 +1,7 @@
 package attestation
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -190,4 +191,21 @@ func TestFetchBundleFromRejectsNonHTTPS(t *testing.T) {
 	_, err := FetchBundleFrom("http://atc.example")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "https")
+}
+
+func TestFetchBundleForRejectsNonHTTPS(t *testing.T) {
+	_, err := FetchBundleFor("http://atc.example", "https://enclave.test", "org/repo")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "https")
+}
+
+func TestBundleRequestJSON(t *testing.T) {
+	b, err := json.Marshal(bundleRequest{EnclaveURL: "https://e.test", Repo: "org/repo"})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"enclaveUrl":"https://e.test","repo":"org/repo"}`, string(b))
+
+	// Empty fields are omitted so the service falls back to its defaults.
+	b, err = json.Marshal(bundleRequest{EnclaveURL: "https://e.test"})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"enclaveUrl":"https://e.test"}`, string(b))
 }

--- a/verifier/client/client.go
+++ b/verifier/client/client.go
@@ -161,6 +161,12 @@ func (s *SecureClient) Verify() (*GroundTruth, error) {
 	// When an attestation bundle URL is configured, attest from the bundle so
 	// the enclave does not need to be reached directly (proxy-friendly).
 	if s.attestationBundleURL != "" {
+		// A pinned measurement and an attestation bundle are mutually exclusive
+		// verification methods: the bundle carries its own code measurement, so
+		// honoring a pinned measurement would be ambiguous.
+		if s.codeMeasurement != nil {
+			return nil, fmt.Errorf("cannot combine a pinned measurement with an attestation bundle URL")
+		}
 		bundle, err := attestation.FetchBundleFrom(s.attestationBundleURL)
 		if err != nil {
 			return nil, fmt.Errorf("fetchBundle: failed to fetch attestation bundle: %v", err)

--- a/verifier/client/client.go
+++ b/verifier/client/client.go
@@ -344,6 +344,12 @@ func (s *SecureClient) makeRequest(req *http.Request) (*Response, error) {
 		req.URL.Host = s.enclave
 	}
 
+	// Request headers (which may carry the API key) are not encrypted, so never
+	// send them over a plaintext connection.
+	if req.URL.Scheme != "https" {
+		return nil, fmt.Errorf("refusing to send request over non-https URL %q", req.URL.String())
+	}
+
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/verifier/client/client.go
+++ b/verifier/client/client.go
@@ -38,6 +38,12 @@ type GroundTruth struct {
 type SecureClient struct {
 	enclave, repo string
 
+	// When set, Verify fetches a pre-assembled attestation bundle from
+	// {attestationBundleURL}/attestation and verifies it client-side instead of
+	// attesting the enclave directly. This lets attestation traffic flow through
+	// a proxy so the client only needs to reach a single origin.
+	attestationBundleURL string
+
 	// Pinned measurement mode
 	codeMeasurement      *attestation.Measurement
 	hardwareMeasurements []*attestation.HardwareMeasurement
@@ -118,6 +124,13 @@ func (s *SecureClient) Repo() string {
 	return s.repo
 }
 
+// SetAttestationBundleURL configures the client to fetch and verify a
+// pre-assembled attestation bundle from {url}/attestation instead of attesting
+// the enclave directly. Pass an empty string to restore direct attestation.
+func (s *SecureClient) SetAttestationBundleURL(url string) {
+	s.attestationBundleURL = url
+}
+
 // GroundTruth returns the last verified enclave state
 func (s *SecureClient) GroundTruth() *GroundTruth {
 	return s.groundTruth
@@ -145,6 +158,16 @@ func (s *SecureClient) getSigstoreClient() (*sigstore.Client, error) {
 
 // Verify fetches the latest verification information from GitHub and Sigstore and stores the ground truth results in the client
 func (s *SecureClient) Verify() (*GroundTruth, error) {
+	// When an attestation bundle URL is configured, attest from the bundle so
+	// the enclave does not need to be reached directly (proxy-friendly).
+	if s.attestationBundleURL != "" {
+		bundle, err := attestation.FetchBundleFrom(s.attestationBundleURL)
+		if err != nil {
+			return nil, fmt.Errorf("fetchBundle: failed to fetch attestation bundle: %v", err)
+		}
+		return s.VerifyFromBundle(bundle)
+	}
+
 	var codeMeasurement = s.codeMeasurement
 	var digest = pinnedNoDigest
 	if s.codeMeasurement == nil {

--- a/verifier/client/client.go
+++ b/verifier/client/client.go
@@ -167,7 +167,17 @@ func (s *SecureClient) Verify() (*GroundTruth, error) {
 		if s.codeMeasurement != nil {
 			return nil, fmt.Errorf("cannot combine a pinned measurement with an attestation bundle URL")
 		}
-		bundle, err := attestation.FetchBundleFrom(s.attestationBundleURL)
+		// Ask the bundle service for an enclave/repo-specific bundle when either
+		// is set; otherwise fetch the default router bundle.
+		enclaveURL := ""
+		if s.enclave != "" {
+			enclaveURL = "https://" + s.enclave
+		}
+		repo := ""
+		if s.repo != defaultRouterRepo {
+			repo = s.repo
+		}
+		bundle, err := attestation.FetchBundleFor(s.attestationBundleURL, enclaveURL, repo)
 		if err != nil {
 			return nil, fmt.Errorf("fetchBundle: failed to fetch attestation bundle: %v", err)
 		}

--- a/verifier/client/client_test.go
+++ b/verifier/client/client_test.go
@@ -98,6 +98,19 @@ func TestVerifyFromBundle(t *testing.T) {
 	assert.Equal(t, bundle.Digest, groundTruth.Digest)
 }
 
+func TestVerifyRejectsPinnedMeasurementWithBundle(t *testing.T) {
+	codeMeasurement := &attestation.Measurement{
+		Type:      attestation.SnpTdxMultiPlatformV1,
+		Registers: []string{"a", "b"},
+	}
+	client := NewPinnedSecureClient("enclave.test", codeMeasurement, nil)
+	client.SetAttestationBundleURL("https://atc.example")
+
+	_, err := client.Verify()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot combine")
+}
+
 func TestVerifyFromBundleJSON(t *testing.T) {
 	bundle, err := attestation.FetchBundle()
 	assert.NoError(t, err)

--- a/verifier/client/roundtrip.go
+++ b/verifier/client/roundtrip.go
@@ -1,13 +1,10 @@
 package client
 
 import (
-	"context"
 	"crypto/tls"
 	"errors"
-	"net"
 	"net/http"
 	"sync"
-	"time"
 
 	"github.com/tinfoilsh/tinfoil-go/verifier/attestation"
 )
@@ -29,42 +26,37 @@ var _ http.RoundTripper = &TLSBoundRoundTripper{}
 func (t *TLSBoundRoundTripper) getTransport() *http.Transport {
 	t.once.Do(func() {
 		// Clone DefaultTransport settings for timeouts, proxy, keep-alive, etc.
-		// then override DialTLSContext to inject our certificate pinning check.
+		// then verify the attested public key after normal TLS verification.
+		// VerifyConnection runs for direct HTTPS and HTTPS-over-CONNECT proxy
+		// connections; DialTLSContext only covers non-proxied HTTPS.
 		dt := http.DefaultTransport.(*http.Transport).Clone()
-		dt.DialTLSContext = t.dialTLSContext
+
+		tlsConfig := &tls.Config{}
+		if dt.TLSClientConfig != nil {
+			tlsConfig = dt.TLSClientConfig.Clone()
+		}
+		prevVerifyConnection := tlsConfig.VerifyConnection
+		tlsConfig.VerifyConnection = func(state tls.ConnectionState) error {
+			if prevVerifyConnection != nil {
+				if err := prevVerifyConnection(state); err != nil {
+					return err
+				}
+			}
+
+			certFP, err := attestation.ConnectionCertFP(state)
+			if err != nil {
+				return err
+			}
+			if certFP != t.ExpectedPublicKey {
+				return ErrCertMismatch
+			}
+			return nil
+		}
+
+		dt.TLSClientConfig = tlsConfig
 		t.transport = dt
 	})
 	return t.transport
-}
-
-// dialTLSContext performs the TLS handshake and verifies the certificate
-// fingerprint BEFORE any HTTP request data is sent over the connection.
-func (t *TLSBoundRoundTripper) dialTLSContext(ctx context.Context, network, addr string) (net.Conn, error) {
-	dialer := &tls.Dialer{
-		NetDialer: &net.Dialer{Timeout: 30 * time.Second},
-	}
-	conn, err := dialer.DialContext(ctx, network, addr)
-	if err != nil {
-		return nil, err
-	}
-
-	tlsConn, ok := conn.(*tls.Conn)
-	if !ok {
-		conn.Close()
-		return nil, ErrNoTLS
-	}
-
-	certFP, err := attestation.ConnectionCertFP(tlsConn.ConnectionState())
-	if err != nil {
-		conn.Close()
-		return nil, err
-	}
-	if certFP != t.ExpectedPublicKey {
-		conn.Close()
-		return nil, ErrCertMismatch
-	}
-
-	return conn, nil
 }
 
 func (t *TLSBoundRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {

--- a/verifier/client/roundtrip_test.go
+++ b/verifier/client/roundtrip_test.go
@@ -1,0 +1,173 @@
+package client
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"io"
+	"log"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tinfoilsh/tinfoil-go/verifier/attestation"
+)
+
+func TestTLSBoundRoundTripperRejectsPinnedMismatchThroughHTTPSProxy(t *testing.T) {
+	var reached atomic.Bool
+	target := newECDSATLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached.Store(true)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer target.Close()
+
+	proxy := newConnectProxy()
+	defer proxy.Close()
+	withDefaultProxyTransport(t, target, proxy)
+
+	client := &http.Client{
+		Transport: &TLSBoundRoundTripper{ExpectedPublicKey: "not-the-attested-key"},
+	}
+	resp, err := client.Get(target.URL)
+	if resp != nil {
+		resp.Body.Close()
+	}
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrCertMismatch), "got %v", err)
+	require.False(t, reached.Load(), "request must not reach the server after a pin mismatch")
+}
+
+func TestTLSBoundRoundTripperAllowsPinnedHTTPSThroughProxy(t *testing.T) {
+	var reached atomic.Bool
+	target := newECDSATLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached.Store(true)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer target.Close()
+
+	proxy := newConnectProxy()
+	defer proxy.Close()
+	withDefaultProxyTransport(t, target, proxy)
+
+	certFP, err := attestation.CertPubkeyFP(target.Certificate())
+	require.NoError(t, err)
+
+	client := &http.Client{
+		Transport: &TLSBoundRoundTripper{ExpectedPublicKey: certFP},
+	}
+	resp, err := client.Get(target.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.True(t, reached.Load())
+}
+
+func withDefaultProxyTransport(t *testing.T, target *httptest.Server, proxy *httptest.Server) {
+	t.Helper()
+
+	proxyURL, err := url.Parse(proxy.URL)
+	require.NoError(t, err)
+	rootCAs := x509.NewCertPool()
+	rootCAs.AddCert(target.Certificate())
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = http.ProxyURL(proxyURL)
+	transport.TLSClientConfig = &tls.Config{RootCAs: rootCAs}
+
+	original := http.DefaultTransport
+	http.DefaultTransport = transport
+	t.Cleanup(func() {
+		http.DefaultTransport = original
+	})
+}
+
+func newECDSATLSServer(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	require.NoError(t, err)
+	leaf, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	server := httptest.NewUnstartedServer(handler)
+	server.Config.ErrorLog = log.New(io.Discard, "", 0)
+	server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{{
+			Certificate: [][]byte{der},
+			PrivateKey:  privateKey,
+			Leaf:        leaf,
+		}},
+	}
+	server.StartTLS()
+	return server
+}
+
+func newConnectProxy() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodConnect {
+			http.Error(w, "CONNECT required", http.StatusMethodNotAllowed)
+			return
+		}
+
+		targetConn, err := net.Dial("tcp", r.Host)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			targetConn.Close()
+			http.Error(w, "hijacking unavailable", http.StatusInternalServerError)
+			return
+		}
+		proxyConn, _, err := hijacker.Hijack()
+		if err != nil {
+			targetConn.Close()
+			return
+		}
+
+		if _, err := proxyConn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
+			proxyConn.Close()
+			targetConn.Close()
+			return
+		}
+
+		go tunnel(proxyConn, targetConn)
+		go tunnel(targetConn, proxyConn)
+	}))
+}
+
+func tunnel(dst net.Conn, src net.Conn) {
+	defer dst.Close()
+	defer src.Close()
+	_, _ = io.Copy(dst, src)
+}

--- a/verifier/util/fetch_other.go
+++ b/verifier/util/fetch_other.go
@@ -12,10 +12,10 @@ func Get(url string) ([]byte, map[string][]string, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode > 299 {
 		return nil, nil, fmt.Errorf("HTTP GET %s: %d %s", url, resp.StatusCode, resp.Status)
 	}
-	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, nil, err
@@ -28,10 +28,10 @@ func Post(url, contentType string, reqBody []byte) ([]byte, map[string][]string,
 	if err != nil {
 		return nil, nil, err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode > 299 {
 		return nil, nil, fmt.Errorf("HTTP POST %s: %d %s", url, resp.StatusCode, resp.Status)
 	}
-	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, nil, err

--- a/verifier/util/fetch_other.go
+++ b/verifier/util/fetch_other.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,6 +14,22 @@ func Get(url string) ([]byte, map[string][]string, error) {
 	}
 	if resp.StatusCode > 299 {
 		return nil, nil, fmt.Errorf("HTTP GET %s: %d %s", url, resp.StatusCode, resp.Status)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+	return body, resp.Header, nil
+}
+
+func Post(url, contentType string, reqBody []byte) ([]byte, map[string][]string, error) {
+	resp, err := http.Post(url, contentType, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.StatusCode > 299 {
+		return nil, nil, fmt.Errorf("HTTP POST %s: %d %s", url, resp.StatusCode, resp.Status)
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)

--- a/verifier/util/fetch_other_test.go
+++ b/verifier/util/fetch_other_test.go
@@ -1,0 +1,72 @@
+package util
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type closeTrackingBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *closeTrackingBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+type stubTransport struct{ resp *http.Response }
+
+func (s *stubTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return s.resp, nil
+}
+
+// withStubResponse points the default client at a stub returning resp and
+// restores the original transport afterwards.
+func withStubResponse(t *testing.T, resp *http.Response) {
+	t.Helper()
+	original := http.DefaultClient.Transport
+	http.DefaultClient.Transport = &stubTransport{resp: resp}
+	t.Cleanup(func() { http.DefaultClient.Transport = original })
+}
+
+func newStubResponse(status int, body *closeTrackingBody) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Body:       body,
+		Header:     make(http.Header),
+	}
+}
+
+func TestPostClosesBodyOnNon2xx(t *testing.T) {
+	body := &closeTrackingBody{Reader: strings.NewReader("error details")}
+	withStubResponse(t, newStubResponse(http.StatusInternalServerError, body))
+
+	_, _, err := Post("http://enclave.example/attestation", "application/json", []byte("{}"))
+	require.Error(t, err)
+	require.True(t, body.closed, "response body must be closed on a non-2xx response")
+}
+
+func TestGetClosesBodyOnNon2xx(t *testing.T) {
+	body := &closeTrackingBody{Reader: strings.NewReader("error details")}
+	withStubResponse(t, newStubResponse(http.StatusBadGateway, body))
+
+	_, _, err := Get("http://enclave.example/attestation")
+	require.Error(t, err)
+	require.True(t, body.closed, "response body must be closed on a non-2xx response")
+}
+
+func TestPostReturnsBodyOn2xx(t *testing.T) {
+	body := &closeTrackingBody{Reader: strings.NewReader("payload")}
+	withStubResponse(t, newStubResponse(http.StatusOK, body))
+
+	got, _, err := Post("http://enclave.example/attestation", "application/json", []byte("{}"))
+	require.NoError(t, err)
+	require.Equal(t, "payload", string(got))
+	require.True(t, body.closed, "response body must be closed after a successful read")
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds encrypted proxy support for EHBP and attestation, so clients can use a proxy while keeping bodies end-to-end encrypted to the verified enclave. Also keeps TLS pinning active through HTTPS proxies and adds review guidance for agents.

- **New Features**
  - `WithBaseURL` routes EHBP requests via a proxy; when origins differ, the SDK adds `X-Tinfoil-Enclave-Url` so the proxy forwards to the verified enclave. The OpenAI base URL is set to the proxy when provided.
  - `WithAttestationBundleURL` fetches and verifies an attestation bundle from `{url}/attestation`, and uses the enclave host from the verified bundle. Supports enclave/repo-specific bundles via POST.
  - Added `AGENTS.md` with guidance on TLS pinning scope and EHBP bundle reviews.

- **Bug Fixes**
  - Bind the HTTP and OpenAI clients to the verified enclave (and optional proxy) and refuse non-HTTPS or foreign-origin requests to prevent header/API key leaks; the `X-Tinfoil-Enclave-Url` header is rebuilt on re-attestation and only set when origins differ.
  - Keep TLS pin checks active for direct HTTPS and HTTPS-over-CONNECT proxy connections.
  - Reject combining a pinned code measurement with `WithAttestationBundleURL`; reject `WithBaseURL` when `TransportTLS` is selected; enforce HTTPS for attestation-bundle URLs.
  - Always close HTTP response bodies on non-2xx responses to prevent resource leaks.

<sup>Written for commit 0382c2c9e69c1ec4ba19762dd6a41e36cc2fc617. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-go/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

