### PR TITLE
sigstore: enforce SPEC §5.4 subject[0]-only artifact digest check

### DIFF
--- a/verifier/sigstore/sigstore.go
+++ b/verifier/sigstore/sigstore.go
@@ -3,6 +3,7 @@ package sigstore
 import (
 	"encoding/hex"
 	"fmt"
+	"strings"
 
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	"github.com/sigstore/sigstore-go/pkg/bundle"
@@ -107,7 +108,38 @@ func (c *Client) VerifyBundle(bundleJSON []byte, repo, hexDigest string) (*verif
 		return nil, fmt.Errorf("verifying: %w", err)
 	}
 
+	// SPEC §5.4: WithArtifactDigest matched the digest against ANY subject in
+	// the in-toto statement; narrow that to subject[0] only, matching the SPEC
+	// and the rs/py/js SDKs.
+	if err := enforceSubject0Digest(result, hexDigest); err != nil {
+		return nil, err
+	}
+
 	return result, nil
+}
+
+// enforceSubject0Digest applies SPEC §5.4: only the FIRST in-toto subject is
+// checked against the expected artifact digest. sigstore-go's WithArtifactDigest
+// matches the digest against ANY subject in the statement (valid generic in-toto
+// semantics — a Statement's subject array may legitimately list several
+// artifacts), so we re-check subject[0] specifically here to honor the SPEC and
+// match the other Tinfoil SDKs (rs/py/js), which all key on subject[0]. Digests
+// are compared case-insensitively (lowercase-normalized per SPEC §7.3).
+func enforceSubject0Digest(result *verify.VerificationResult, expectedDigest string) error {
+	if result == nil || result.Statement == nil {
+		return fmt.Errorf("verification result has no in-toto statement")
+	}
+	if len(result.Statement.Subject) == 0 {
+		return fmt.Errorf("in-toto statement has no subject")
+	}
+	got := result.Statement.Subject[0].Digest["sha256"]
+	if !strings.EqualFold(got, expectedDigest) {
+		return fmt.Errorf(
+			"subject[0] digest %q does not match expected artifact digest %q",
+			got, expectedDigest,
+		)
+	}
+	return nil
 }
 
 func (c *Client) VerifyAttestation(


### PR DESCRIPTION
VerifyBundle delegated artifact-digest matching to sigstore-go's WithArtifactDigest, which matches the expected digest against ANY subject in the in-toto statement (valid generic in-toto semantics — a Statement's subject array may list several artifacts). SPEC §5.4 is stricter: "If the subject array contains multiple entries, only the first entry (subject[0]) is checked." So a statement whose subject[0] carries a different digest while a later subject matches the expected one was wrongly accepted — diverging from tinfoil-rs/-py/-js, which all key on subject[0].

Add enforceSubject0Digest and call it after verification in VerifyBundle, so every consumer (VerifyAttestation, FetchHardwareMeasurements) rejects with SUBJECT_DIGEST_MISMATCH when subject[0] doesn't match, even though sigstore-go accepted via another subject. Happy-path (single-subject) bundles are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces SPEC §5.4 by checking the artifact digest against subject[0] only during Sigstore verification. Prevents bundles from passing when a later subject matches, aligning with `tinfoil-rs`, `tinfoil-py`, and `tinfoil-js`.

- **Bug Fixes**
  - Added `enforceSubject0Digest` after `sigstore-go` verification in `VerifyBundle` to enforce subject[0]-only matching.
  - Returns `SUBJECT_DIGEST_MISMATCH` when subject[0] differs; errors on missing statement/subject or digest.
  - Case-insensitive digest compare per SPEC §7.3.
  - Applies to all consumers of `VerifyBundle` (`VerifyAttestation`, `FetchHardwareMeasurements`).

<sup>Written for commit 3a1656dab989893e9cf8b6d1fc806c2cf55ba4e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-go/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

