### PR TITLE
sigstore: reject legacy x509CertificateChain bundle format (SPEC §5.2)

### DIFF
--- a/verifier/sigstore/bundle_format.go
+++ b/verifier/sigstore/bundle_format.go
@@ -1,0 +1,22 @@
+package sigstore
+
+import (
+	"fmt"
+
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+)
+
+// rejectLegacyBundleFormat enforces SPEC §5.2: only the v0.3 single-certificate
+// bundle layout is accepted. The legacy v0.1/v0.2 layout conveys the signing
+// certificate under verificationMaterial.x509CertificateChain, which may also
+// carry intermediate or root CA certificates — a misuse vector the v0.3
+// single-certificate form avoids. sigstore-go parses the legacy layout (it is a
+// valid oneof in the protobuf schema), so we reject it here. tinfoil only ever
+// produces v0.3 bundles; this matches tinfoil-rs, which also rejects the legacy
+// form.
+func rejectLegacyBundleFormat(b *protobundle.Bundle) error {
+	if b.GetVerificationMaterial().GetX509CertificateChain() != nil {
+		return fmt.Errorf("legacy bundle format not supported: the x509CertificateChain layout requires the v0.3 single-certificate form")
+	}
+	return nil
+}

--- a/verifier/sigstore/sigstore.go
+++ b/verifier/sigstore/sigstore.go
@@ -71,6 +71,9 @@ func (c *Client) VerifyBundle(bundleJSON []byte, repo, hexDigest string) (*verif
 	if err := b.UnmarshalJSON(bundleJSON); err != nil {
 		return nil, fmt.Errorf("parsing bundle: %w", err)
 	}
+	if err := rejectLegacyBundleFormat(b.Bundle); err != nil {
+		return nil, err
+	}
 
 	verifier, err := verify.NewSignedEntityVerifier(
 		c.trustRoot,


### PR DESCRIPTION
sigstore-go parses the legacy v0.1/v0.2 bundle layout (signing cert under verificationMaterial.x509CertificateChain — a valid protobuf oneof). Per SPEC §5.2 the legacy layout MUST be rejected: tinfoil only produces v0.3 bundles.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject legacy Sigstore bundle layout (v0.1/v0.2) by erroring when verificationMaterial.x509CertificateChain is present, enforcing SPEC §5.2 and allowing only v0.3 single-certificate bundles. The check runs right after parsing in VerifyBundle to cover all consumers and align with `tinfoil-rs`/`tinfoil-py`/`tinfoil-js`.

<sup>Written for commit 938a2b03f1251a22dbf0263e752b69ecd4086045. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-go/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

