### PR TITLE
Provision user_cache_secret for per-user prompt cache scoping (Phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,33 @@ if err != nil {
 }
 ```
 
+## Prompt Cache Scoping
+
+The inference router partitions its prompt cache per API identity, so your cached prompts are never observable by other tenants. Within your tenant, the SDK scopes caching further with a `user_cache_secret`: requests carrying the same secret share cached prompt prefixes, requests carrying different secrets cannot observe each other's cache timing. The secret never reaches the model — the router consumes it to derive the cache namespace and strips it from the request.
+
+By default the SDK generates a random secret and persists it at `~/.tinfoil/user_cache_secret` (mode `0600`, shared with the other Tinfoil SDKs on the same machine), so caching just works with per-machine scoping. You can control it explicitly:
+
+```go
+// Pin the secret for this client (e.g. one stable value per end user)
+client, err := tinfoil.NewClientWithOptions(
+	tinfoil.WithUserCacheSecret(secret),
+)
+
+// Or provision it via the environment
+//   TINFOIL_USER_CACHE_SECRET=<secret>   use this value
+//   TINFOIL_USER_CACHE_SECRET=           (set but empty) disable: tenant-wide caching
+
+// Servers that hold many end users' conversations should scope per request;
+// a field set here always wins over the client-level secret:
+completion, err := client.Chat.Completions.New(ctx, params,
+	option.WithJSONSet("user_cache_secret", perUserSecret))
+
+// Opt out entirely (tenant-wide caching, no file written)
+client, err = tinfoil.NewClientWithOptions(tinfoil.WithUserCacheSecret(""))
+```
+
+If the secret cannot be persisted (no home directory, read-only filesystem), the SDK falls back to an in-memory secret and warns once: cache continuity then resets on every process restart. Containerized deployments should set `TINFOIL_USER_CACHE_SECRET` explicitly — one value per end user if requests are per-user, or empty to keep tenant-wide caching across replicas.
+
 ## API Documentation
 
 This library is a drop-in replacement for the [official OpenAI Go client](https://github.com/openai/openai-go) that can be used with Tinfoil. All methods and types are identical. See the [OpenAI Go client documentation](https://pkg.go.dev/github.com/openai/openai-go/v3) for complete API usage and documentation.

--- a/ehbp_transport.go
+++ b/ehbp_transport.go
@@ -43,6 +43,8 @@ type clientConfig struct {
 	transport            TransportMode
 	baseURL              string
 	attestationBundleURL string
+	userCacheSecret      string
+	userCacheSecretSet   bool
 	openaiOpts           []option.RequestOption
 }
 
@@ -130,7 +132,8 @@ func NewClientWithOptions(opts ...ClientOption) (*Client, error) {
 		secureClient = client.NewSecureClient(cfg.enclave, cfg.repo)
 	}
 
-	return createClientFromSecureClient(secureClient, cfg.transport, cfg.baseURL, cfg.openaiOpts...)
+	return createClientFromSecureClient(secureClient, cfg.transport, cfg.baseURL,
+		resolveUserCacheSecret(cfg.userCacheSecret, cfg.userCacheSecretSet), cfg.openaiOpts...)
 }
 
 // secureHTTPClient builds an *http.Client for the requested transport mode.
@@ -139,7 +142,7 @@ func NewClientWithOptions(opts ...ClientOption) (*Client, error) {
 // proxy, if any): neither EHBP nor TLS pinning encrypts request headers, which
 // may carry the API key, so requests to any other host or over plain http are
 // refused.
-func secureHTTPClient(secureClient *client.SecureClient, mode TransportMode, baseURL string) (*http.Client, error) {
+func secureHTTPClient(secureClient *client.SecureClient, mode TransportMode, baseURL, userCacheSecret string) (*http.Client, error) {
 	var (
 		httpClient *http.Client
 		err        error
@@ -156,6 +159,17 @@ func secureHTTPClient(secureClient *client.SecureClient, mode TransportMode, bas
 		return nil, err
 	}
 
+	// The cache-secret layer sits above the sealing transport, so the field it
+	// injects is encrypted with the rest of the body (EHBP) or sent over the
+	// pinned connection (TLS).
+	transport := httpClient.Transport
+	if userCacheSecret != "" {
+		transport = &userCacheSecretTransport{
+			secret:    userCacheSecret,
+			transport: transport,
+		}
+	}
+
 	origins, err := allowedOrigins(secureClient.Enclave(), baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine allowed request origins: %w", err)
@@ -163,7 +177,7 @@ func secureHTTPClient(secureClient *client.SecureClient, mode TransportMode, bas
 	httpClient.Transport = &hostBoundRoundTripper{
 		allowedOrigins: origins,
 		enclave:        secureClient.Enclave(),
-		transport:      httpClient.Transport,
+		transport:      transport,
 	}
 	return httpClient, nil
 }

--- a/tinfoil_client.go
+++ b/tinfoil_client.go
@@ -77,7 +77,7 @@ type Client struct {
 // NewClientWithParams creates a new secure OpenAI client with explicit enclave and repo parameters
 func NewClientWithParams(enclave, repo string, openaiOpts ...option.RequestOption) (*Client, error) {
 	secureClient := client.NewSecureClient(enclave, repo)
-	return createClientFromSecureClient(secureClient, defaultTransportMode, "", openaiOpts...)
+	return createClientFromSecureClient(secureClient, defaultTransportMode, "", resolveUserCacheSecret("", false), openaiOpts...)
 }
 
 // NewClient creates a new secure OpenAI client using default parameters
@@ -86,12 +86,12 @@ func NewClient(openaiOpts ...option.RequestOption) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create secure client: %w", err)
 	}
-	return createClientFromSecureClient(secureClient, defaultTransportMode, "", openaiOpts...)
+	return createClientFromSecureClient(secureClient, defaultTransportMode, "", resolveUserCacheSecret("", false), openaiOpts...)
 }
 
 // createClientFromSecureClient is a helper function to create a Client from a SecureClient
-func createClientFromSecureClient(secureClient *client.SecureClient, mode TransportMode, baseURL string, openaiOpts ...option.RequestOption) (*Client, error) {
-	httpClient, err := secureHTTPClient(secureClient, mode, baseURL)
+func createClientFromSecureClient(secureClient *client.SecureClient, mode TransportMode, baseURL, userCacheSecret string, openaiOpts ...option.RequestOption) (*Client, error) {
+	httpClient, err := secureHTTPClient(secureClient, mode, baseURL, userCacheSecret)
 	if err != nil {
 		return nil, err
 	}

--- a/tinfoil_client_test.go
+++ b/tinfoil_client_test.go
@@ -189,6 +189,7 @@ func TestDirectClientStreamingChat(t *testing.T) {
 }
 
 func TestHTTPClient(t *testing.T) {
+	t.Setenv(userCacheSecretEnv, "test-secret")
 	client, err := NewClient()
 	require.NoError(t, err)
 
@@ -196,11 +197,14 @@ func TestHTTPClient(t *testing.T) {
 	require.NotNil(t, httpClient, "HTTPClient() should return a non-nil client")
 
 	// The outermost transport binds requests to the enclave/proxy host; the
-	// EHBP re-verifying transport (the default mode) sits inside it.
+	// user-cache-secret layer injects into the body before the EHBP
+	// re-verifying transport (the default mode) seals it.
 	hostBound, ok := httpClient.Transport.(*hostBoundRoundTripper)
 	require.True(t, ok, "HTTPClient transport should be hostBoundRoundTripper")
-	_, ok = hostBound.transport.(*ehbpReVerifyingTransport)
-	require.True(t, ok, "inner transport should be ehbpReVerifyingTransport")
+	ucs, ok := hostBound.transport.(*userCacheSecretTransport)
+	require.True(t, ok, "inner transport should inject the user cache secret")
+	_, ok = ucs.transport.(*ehbpReVerifyingTransport)
+	require.True(t, ok, "sealing transport should be ehbpReVerifyingTransport")
 
 	// Verify it returns the same instance (shared client)
 	httpClient2 := client.HTTPClient()

--- a/user_cache_secret.go
+++ b/user_cache_secret.go
@@ -1,0 +1,255 @@
+package tinfoil
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// user_cache_secret provisions the per-user prompt-cache secret defined by the
+// secure prompt caching contract. The router derives the request's prefix-cache
+// namespace from it: requests carrying the same secret (under the same API
+// identity) share cached prompt prefixes, requests carrying different secrets
+// cannot observe each other's cache timing. The secret itself is stripped by
+// the router and never reaches the model.
+//
+// Resolution order, mirroring the other Tinfoil clients:
+//
+//  1. an explicit per-request `user_cache_secret` field in the body (never
+//     overwritten here),
+//  2. WithUserCacheSecret,
+//  3. the TINFOIL_USER_CACHE_SECRET environment variable,
+//  4. a generated secret persisted at ~/.tinfoil/user_cache_secret (0600),
+//     shared with the other Tinfoil SDKs on the same machine.
+//
+// Injection happens in the transport, before the EHBP transport seals the
+// body, so the secret is only ever visible to the verified enclave.
+
+const (
+	// userCacheSecretField is the router-only request-body field. A non-empty
+	// string scopes the prompt cache to that secret; an absent or empty value
+	// leaves the request in the tenant-wide namespace.
+	userCacheSecretField = "user_cache_secret"
+
+	// userCacheSecretEnv provisions the secret via the environment. Setting it
+	// to an empty string disables generation entirely (tenant-wide caching),
+	// which is the right call for pooled multi-user deployments that would
+	// otherwise mint a fresh namespace per container.
+	userCacheSecretEnv = "TINFOIL_USER_CACHE_SECRET"
+
+	// userCacheSecretFile is the persisted-secret path under the home
+	// directory. The other Tinfoil SDKs use the same file, so one machine gets
+	// one cache namespace across tools.
+	userCacheSecretDirName  = ".tinfoil"
+	userCacheSecretFileName = "user_cache_secret"
+)
+
+// userCacheSecretPaths are the OpenAI-compatible endpoints whose bodies carry
+// the field. Matched by suffix so a proxy base URL with a path prefix still
+// qualifies. Other endpoints (embeddings, audio, files) are excluded: their
+// engines do not prefix-cache and may reject unknown fields.
+var userCacheSecretPaths = []string{
+	"/v1/chat/completions",
+	"/v1/completions",
+	"/v1/responses",
+}
+
+// WithUserCacheSecret sets the user cache secret explicitly, taking precedence
+// over the environment variable and the generated secret. Use one stable value
+// per end user: a server holding many end users' conversations should instead
+// set the field per request, which always wins over the client-level secret:
+//
+//	client.Chat.Completions.New(ctx, params,
+//		option.WithJSONSet("user_cache_secret", perUserSecret))
+//
+// An empty string disables injection and generation entirely, leaving every
+// request in the tenant-wide cache namespace.
+func WithUserCacheSecret(secret string) ClientOption {
+	return func(c *clientConfig) {
+		c.userCacheSecret = secret
+		c.userCacheSecretSet = true
+	}
+}
+
+// resolveUserCacheSecret resolves the client-level secret: the explicit option
+// wins, then the environment, then the persisted (or generated) secret. An
+// empty result means injection is disabled.
+func resolveUserCacheSecret(explicit string, explicitSet bool) string {
+	if explicitSet {
+		return explicit
+	}
+	if env, ok := os.LookupEnv(userCacheSecretEnv); ok {
+		return env
+	}
+	return loadOrGenerateUserCacheSecret()
+}
+
+// newUserCacheSecret returns a fresh 256-bit random secret, hex-encoded.
+func newUserCacheSecret() string {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// Never fall back to a weak secret: no secret means tenant-wide
+		// caching, which is safe.
+		log.WithError(err).Warn("tinfoil: could not generate a user cache secret; requests stay in the tenant-wide cache namespace")
+		return ""
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// ephemeralUserCacheSecret is the process-lifetime fallback for when the
+// secret cannot be persisted. An unpersisted secret still isolates this
+// process's cache namespace, but continuity is lost on restart — like a
+// session ID, it silently resets the namespace every deploy — so the fallback
+// warns once per process.
+var ephemeralUserCacheSecret = sync.OnceValue(func() string {
+	secret := newUserCacheSecret()
+	if secret != "" {
+		log.Warnf("tinfoil: could not persist the user cache secret; using an in-memory secret, so prompt-cache continuity resets when this process exits (set %s or WithUserCacheSecret to pin one)", userCacheSecretEnv)
+	}
+	return secret
+})
+
+// loadOrGenerateUserCacheSecret returns the secret persisted under the user's
+// home directory, generating and persisting one on first use. When the home
+// directory is unavailable or unwritable it falls back to a process-lifetime
+// in-memory secret.
+func loadOrGenerateUserCacheSecret() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ephemeralUserCacheSecret()
+	}
+	dir := filepath.Join(home, userCacheSecretDirName)
+	path := filepath.Join(dir, userCacheSecretFileName)
+
+	if b, err := os.ReadFile(path); err == nil {
+		if s := strings.TrimSpace(string(b)); s != "" {
+			return s
+		}
+	}
+
+	secret := newUserCacheSecret()
+	if secret == "" {
+		return ""
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return ephemeralUserCacheSecret()
+	}
+
+	// O_EXCL so a concurrent first run loses the race cleanly: the loser
+	// re-reads and adopts the winner's secret instead of splitting the
+	// machine's namespace between two values.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	switch {
+	case err == nil:
+		_, werr := f.WriteString(secret)
+		cerr := f.Close()
+		if werr == nil && cerr == nil {
+			return secret
+		}
+	case errors.Is(err, fs.ErrExist):
+		if b, rerr := os.ReadFile(path); rerr == nil {
+			if s := strings.TrimSpace(string(b)); s != "" {
+				return s
+			}
+		}
+	default:
+		return ephemeralUserCacheSecret()
+	}
+
+	// The file exists but is blank or torn: rewrite it in place.
+	if err := os.WriteFile(path, []byte(secret), 0o600); err != nil {
+		return ephemeralUserCacheSecret()
+	}
+	return secret
+}
+
+// userCacheSecretTransport injects the client-level secret into request bodies
+// on the way out. It sits above the sealing transport (EHBP or pinned TLS), so
+// the field is added before the body is encrypted, and below the host-binding
+// guard. A field already present in the body is never overwritten — an
+// explicit per-request value, including an explicit empty string (= opt out
+// for that request), always wins.
+type userCacheSecretTransport struct {
+	secret    string
+	transport http.RoundTripper
+}
+
+func (t *userCacheSecretTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.secret == "" || !userCacheSecretPathEligible(req) {
+		return t.transport.RoundTrip(req)
+	}
+
+	raw, err := io.ReadAll(req.Body)
+	req.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	newBody, changed := injectUserCacheSecret(raw, t.secret)
+	out := req.Clone(req.Context())
+	if !changed {
+		// Not a JSON object, or the caller set the field: forward the
+		// original bytes untouched.
+		out.Body = io.NopCloser(bytes.NewReader(raw))
+		return t.transport.RoundTrip(out)
+	}
+
+	out.Body = io.NopCloser(bytes.NewReader(newBody))
+	out.ContentLength = int64(len(newBody))
+	out.Header.Set("Content-Length", strconv.Itoa(len(newBody)))
+	// Retries below this layer (EHBP key rotation, redirects) must replay the
+	// injected body, not the caller's original.
+	out.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(newBody)), nil
+	}
+	return t.transport.RoundTrip(out)
+}
+
+// userCacheSecretPathEligible reports whether the request can carry the field:
+// a POST with a body to one of the supported endpoints.
+func userCacheSecretPathEligible(req *http.Request) bool {
+	if req.Method != http.MethodPost || req.Body == nil || req.Body == http.NoBody {
+		return false
+	}
+	for _, p := range userCacheSecretPaths {
+		if strings.HasSuffix(req.URL.Path, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// injectUserCacheSecret adds the field to a JSON-object body, preserving
+// number precision across the re-marshal (float64 round-tripping would corrupt
+// int64-range values such as seed). It reports false — forward the original
+// bytes — for non-object bodies, trailing data, or a body that already carries
+// the field.
+func injectUserCacheSecret(raw []byte, secret string) ([]byte, bool) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var body map[string]any
+	if err := dec.Decode(&body); err != nil || dec.More() || body == nil {
+		return nil, false
+	}
+	if _, ok := body[userCacheSecretField]; ok {
+		return nil, false
+	}
+	body[userCacheSecretField] = secret
+	newBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, false
+	}
+	return newBody, true
+}

--- a/user_cache_secret.go
+++ b/user_cache_secret.go
@@ -240,7 +240,7 @@ func injectUserCacheSecret(raw []byte, secret string) ([]byte, bool) {
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.UseNumber()
 	var body map[string]any
-	if err := dec.Decode(&body); err != nil || dec.More() || body == nil {
+	if err := dec.Decode(&body); err != nil || !decodeConsumedAll(dec) || body == nil {
 		return nil, false
 	}
 	if _, ok := body[userCacheSecretField]; ok {
@@ -252,4 +252,15 @@ func injectUserCacheSecret(raw []byte, secret string) ([]byte, bool) {
 		return nil, false
 	}
 	return newBody, true
+}
+
+// decodeConsumedAll reports whether dec has nothing left but trailing
+// whitespace: a follow-up Token read returns io.EOF only at true end of
+// input. dec.More() is not enough here — it reports "no more elements" at a
+// trailing '}' or ']', so a malformed body like `{...}}` would be
+// re-marshaled without its trailing bytes and a request the server rejects
+// would quietly become one it accepts.
+func decodeConsumedAll(dec *json.Decoder) bool {
+	_, err := dec.Token()
+	return err == io.EOF
 }

--- a/user_cache_secret_test.go
+++ b/user_cache_secret_test.go
@@ -1,0 +1,310 @@
+package tinfoil
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/stretchr/testify/require"
+)
+
+// unsetUserCacheSecretEnv removes TINFOIL_USER_CACHE_SECRET for the test (a
+// developer .env loaded by TestMain may set it) and restores it afterwards.
+func unsetUserCacheSecretEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(userCacheSecretEnv, "placeholder") // registers restoration
+	require.NoError(t, os.Unsetenv(userCacheSecretEnv))
+}
+
+func TestWithUserCacheSecretOption(t *testing.T) {
+	cfg := &clientConfig{}
+	WithUserCacheSecret("s1")(cfg)
+	require.Equal(t, "s1", cfg.userCacheSecret)
+	require.True(t, cfg.userCacheSecretSet)
+
+	cfg = &clientConfig{}
+	WithUserCacheSecret("")(cfg)
+	require.Empty(t, cfg.userCacheSecret)
+	require.True(t, cfg.userCacheSecretSet, "an explicit empty secret must still count as set (it disables provisioning)")
+}
+
+func TestResolveUserCacheSecretPrecedence(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	t.Run("explicit option beats environment", func(t *testing.T) {
+		t.Setenv(userCacheSecretEnv, "from-env")
+		require.Equal(t, "explicit", resolveUserCacheSecret("explicit", true))
+	})
+
+	t.Run("explicit empty disables even with environment set", func(t *testing.T) {
+		t.Setenv(userCacheSecretEnv, "from-env")
+		require.Empty(t, resolveUserCacheSecret("", true))
+	})
+
+	t.Run("environment beats generation and touches no file", func(t *testing.T) {
+		t.Setenv(userCacheSecretEnv, "from-env")
+		require.Equal(t, "from-env", resolveUserCacheSecret("", false))
+		_, err := os.Stat(filepath.Join(home, userCacheSecretDirName))
+		require.True(t, os.IsNotExist(err), "an environment-provided secret must not create the secret file")
+	})
+
+	t.Run("environment set but empty disables generation", func(t *testing.T) {
+		t.Setenv(userCacheSecretEnv, "")
+		require.Empty(t, resolveUserCacheSecret("", false))
+		_, err := os.Stat(filepath.Join(home, userCacheSecretDirName))
+		require.True(t, os.IsNotExist(err), "a disabled secret must not create the secret file")
+	})
+}
+
+func TestUserCacheSecretGenerateAndPersist(t *testing.T) {
+	unsetUserCacheSecretEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	first := resolveUserCacheSecret("", false)
+	require.Len(t, first, 64, "expected a hex-encoded 256-bit secret")
+
+	path := filepath.Join(home, userCacheSecretDirName, userCacheSecretFileName)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	// A second resolution (a new client, or another SDK on the same machine)
+	// must reuse the persisted secret, not mint a new namespace.
+	require.Equal(t, first, resolveUserCacheSecret("", false))
+}
+
+func TestUserCacheSecretAdoptsExistingFile(t *testing.T) {
+	unsetUserCacheSecretEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(home, userCacheSecretDirName)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	// Trailing newline: the file may be hand-edited or written by another SDK.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, userCacheSecretFileName), []byte("shared-secret\n"), 0o600))
+
+	require.Equal(t, "shared-secret", resolveUserCacheSecret("", false))
+}
+
+func TestUserCacheSecretRewritesBlankFile(t *testing.T) {
+	unsetUserCacheSecretEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(home, userCacheSecretDirName)
+	path := filepath.Join(dir, userCacheSecretFileName)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	require.NoError(t, os.WriteFile(path, []byte("  \n"), 0o600))
+
+	secret := resolveUserCacheSecret("", false)
+	require.Len(t, secret, 64)
+
+	written, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, secret, strings.TrimSpace(string(written)), "a blank file must be replaced with the generated secret")
+}
+
+func TestUserCacheSecretFallsBackWithoutHome(t *testing.T) {
+	unsetUserCacheSecretEnv(t)
+	t.Setenv("HOME", "")
+
+	first := resolveUserCacheSecret("", false)
+	require.NotEmpty(t, first, "no home directory must still yield a process-lifetime secret")
+	require.Equal(t, first, resolveUserCacheSecret("", false), "the in-memory fallback must be stable within the process")
+}
+
+func TestUserCacheSecretFallsBackWhenHomeNotADirectory(t *testing.T) {
+	unsetUserCacheSecretEnv(t)
+	homeFile := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(homeFile, []byte("x"), 0o600))
+	t.Setenv("HOME", homeFile)
+
+	require.NotEmpty(t, resolveUserCacheSecret("", false))
+}
+
+// captureTransport returns a userCacheSecretTransport whose inner round
+// tripper records the outgoing body.
+func captureTransport(secret string, gotBody *[]byte, gotReq **http.Request) *userCacheSecretTransport {
+	return &userCacheSecretTransport{
+		secret: secret,
+		transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Body != nil {
+				b, err := io.ReadAll(req.Body)
+				if err != nil {
+					return nil, err
+				}
+				*gotBody = b
+			}
+			if gotReq != nil {
+				*gotReq = req
+			}
+			return newResponse(http.StatusOK, "ok"), nil
+		}),
+	}
+}
+
+func postJSONRequest(t *testing.T, url, body string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func TestUserCacheSecretTransportInjects(t *testing.T) {
+	paths := []string{
+		"/v1/chat/completions",
+		"/v1/completions",
+		"/v1/responses",
+		"/api/v1/chat/completions", // proxy base URL with a path prefix
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			var got []byte
+			var sent *http.Request
+			transport := captureTransport("s1", &got, &sent)
+
+			req := postJSONRequest(t, "https://enclave.example.com"+path, `{"model":"m"}`)
+			resp, err := transport.RoundTrip(req)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			var body map[string]any
+			require.NoError(t, json.Unmarshal(got, &body))
+			require.Equal(t, "s1", body[userCacheSecretField])
+
+			// Length metadata and the replayable body must describe the
+			// injected bytes: retries below this layer (EHBP key rotation)
+			// re-send via GetBody.
+			require.Equal(t, int64(len(got)), sent.ContentLength)
+			require.Equal(t, strconv.Itoa(len(got)), sent.Header.Get("Content-Length"))
+			require.NotNil(t, sent.GetBody)
+			replay, err := sent.GetBody()
+			require.NoError(t, err)
+			replayed, err := io.ReadAll(replay)
+			require.NoError(t, err)
+			require.Equal(t, got, replayed)
+		})
+	}
+}
+
+func TestUserCacheSecretTransportSkipsIneligibleRequests(t *testing.T) {
+	t.Run("non-allowlisted endpoint forwards the body untouched", func(t *testing.T) {
+		var got []byte
+		transport := captureTransport("s1", &got, nil)
+		const raw = `{"model":"m","input":"text"}`
+		_, err := transport.RoundTrip(postJSONRequest(t, "https://enclave.example.com/v1/embeddings", raw))
+		require.NoError(t, err)
+		require.Equal(t, raw, string(got))
+	})
+
+	t.Run("GET with no body is forwarded as-is", func(t *testing.T) {
+		transport := captureTransport("s1", nil, nil)
+		req, err := http.NewRequest(http.MethodGet, "https://enclave.example.com/v1/models", nil)
+		require.NoError(t, err)
+		resp, err := transport.RoundTrip(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("empty secret disables injection", func(t *testing.T) {
+		var got []byte
+		transport := captureTransport("", &got, nil)
+		const raw = `{"model":"m"}`
+		_, err := transport.RoundTrip(postJSONRequest(t, "https://enclave.example.com/v1/chat/completions", raw))
+		require.NoError(t, err)
+		require.Equal(t, raw, string(got))
+	})
+}
+
+func TestUserCacheSecretTransportNeverClobbers(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"explicit per-request secret", `{"model":"m","user_cache_secret":"end-user-7"}`},
+		{"explicit empty opt-out", `{"model":"m","user_cache_secret":""}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got []byte
+			transport := captureTransport("client-level", &got, nil)
+			_, err := transport.RoundTrip(postJSONRequest(t, "https://enclave.example.com/v1/chat/completions", tc.raw))
+			require.NoError(t, err)
+			require.Equal(t, tc.raw, string(got), "a body that already carries the field must pass through byte-identical")
+		})
+	}
+}
+
+func TestUserCacheSecretTransportNonObjectBodies(t *testing.T) {
+	for _, raw := range []string{`not json`, `[1,2,3]`, `null`, `{"model":"m"} trailing`} {
+		t.Run(raw, func(t *testing.T) {
+			var got []byte
+			transport := captureTransport("s1", &got, nil)
+			_, err := transport.RoundTrip(postJSONRequest(t, "https://enclave.example.com/v1/chat/completions", raw))
+			require.NoError(t, err)
+			require.Equal(t, raw, string(got), "bodies the router-side schema would reject must be forwarded untouched")
+		})
+	}
+}
+
+func TestUserCacheSecretTransportPreservesNumberPrecision(t *testing.T) {
+	// 2^53+1 is not representable as float64; naive decoding would corrupt it.
+	var got []byte
+	transport := captureTransport("s1", &got, nil)
+	_, err := transport.RoundTrip(postJSONRequest(t,
+		"https://enclave.example.com/v1/chat/completions", `{"model":"m","seed":9007199254740993}`))
+	require.NoError(t, err)
+	require.Contains(t, string(got), `"seed":9007199254740993`)
+}
+
+// TestUserCacheSecretThroughOpenAIClient drives the real OpenAI client through
+// the injection transport to a local server, pinning that the secret rides
+// requests exactly as the SDK builds them — and that a per-request field set
+// via request options wins over the client-level secret.
+func TestUserCacheSecretThroughOpenAIClient(t *testing.T) {
+	var received map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/chat/completions", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&received))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"c1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"}}]}`))
+	}))
+	defer server.Close()
+
+	httpClient := &http.Client{Transport: &userCacheSecretTransport{
+		secret:    "client-level",
+		transport: http.DefaultTransport,
+	}}
+	oai := openai.NewClient(
+		option.WithAPIKey("test"),
+		option.WithBaseURL(server.URL+"/v1/"),
+		option.WithHTTPClient(httpClient),
+	)
+
+	params := openai.ChatCompletionNewParams{
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+		Model:    "m",
+	}
+
+	_, err := oai.Chat.Completions.New(context.Background(), params)
+	require.NoError(t, err)
+	require.Equal(t, "client-level", received[userCacheSecretField])
+
+	_, err = oai.Chat.Completions.New(context.Background(), params,
+		option.WithJSONSet(userCacheSecretField, "end-user-7"))
+	require.NoError(t, err)
+	require.Equal(t, "end-user-7", received[userCacheSecretField],
+		"a per-request field must win over the client-level secret")
+}

--- a/user_cache_secret_test.go
+++ b/user_cache_secret_test.go
@@ -248,7 +248,18 @@ func TestUserCacheSecretTransportNeverClobbers(t *testing.T) {
 }
 
 func TestUserCacheSecretTransportNonObjectBodies(t *testing.T) {
-	for _, raw := range []string{`not json`, `[1,2,3]`, `null`, `{"model":"m"} trailing`} {
+	// The trailing '}' / ']' cases are the regression: dec.More() reports
+	// "no more elements" at either byte, so they used to be re-marshaled
+	// with the trailing bytes silently dropped.
+	for _, raw := range []string{
+		`not json`,
+		`[1,2,3]`,
+		`null`,
+		`{"model":"m"} trailing`,
+		`{"model":"m"}}`,
+		`{"model":"m"}]`,
+		`{"model":"m"}} garbage`,
+	} {
 		t.Run(raw, func(t *testing.T) {
 			var got []byte
 			transport := captureTransport("s1", &got, nil)
@@ -257,6 +268,20 @@ func TestUserCacheSecretTransportNonObjectBodies(t *testing.T) {
 			require.Equal(t, raw, string(got), "bodies the router-side schema would reject must be forwarded untouched")
 		})
 	}
+}
+
+func TestUserCacheSecretTransportAllowsTrailingWhitespace(t *testing.T) {
+	// Trailing whitespace is not trailing data: strict JSON parsers accept
+	// it, so the injection must too — clients routinely end bodies with \n.
+	var got []byte
+	transport := captureTransport("s1", &got, nil)
+	_, err := transport.RoundTrip(postJSONRequest(t,
+		"https://enclave.example.com/v1/chat/completions", "{\"model\":\"m\"}\n\t "))
+	require.NoError(t, err)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(got, &body))
+	require.Equal(t, "s1", body[userCacheSecretField])
 }
 
 func TestUserCacheSecretTransportPreservesNumberPrecision(t *testing.T) {


### PR DESCRIPTION
Implements secure prompt caching **Phase 2 (client-side provisioning)** for the Go SDK, per the §1 contract frozen with the router work (tinfoilsh/confidential-model-router#386 / #387): `user_cache_secret` is an optional string in the JSON body of OpenAI-compatible requests; a non-empty value scopes the tenant's prefix-cache namespace per user; the router consumes and strips it — it never reaches the model.

## What

- **`WithUserCacheSecret(secret)`** — explicit client-level secret. An explicit empty string disables provisioning entirely (tenant-wide caching, no file written).
- **`TINFOIL_USER_CACHE_SECRET`** — environment provisioning. Set-but-empty also disables: the off switch for pooled multi-user deployments that would otherwise mint a fresh namespace per container.
- **Generate-and-persist default** — 256-bit random secret at `~/.tinfoil/user_cache_secret` (`0600`, dir `0700`), written with `O_EXCL` so two racing first-runs converge on one value instead of splitting the machine's namespace. The path is shared with the other Tinfoil SDKs so one machine gets one namespace across tools.
- **In-memory fallback + one-time warning** when persistence is unavailable (no home dir, read-only FS). An unpersisted secret behaves like a session ID — cache continuity silently resets every restart — so the fallback warns once per process and points at the env var / option.

## How injection works

A new transport layer sits between the host-binding guard and the sealing transport: `hostBound → userCacheSecret → EHBP (or pinned TLS)`. That placement means:

- the field is added **before EHBP seals the body**, so it is only ever visible to the verified enclave;
- retries below the layer (HPKE key-rotation re-verify) replay the **injected** bytes — `GetBody`, `ContentLength`, and the `Content-Length` header are all rewritten to describe the new body.

Precedence follows the contract: **explicit body field > client option > env > generated.** A field already present in the body is never overwritten — including an explicit empty string (per-request opt-out) — so multi-user servers scope per request with `option.WithJSONSet("user_cache_secret", perUserSecret)`.

Injection is limited to `/v1/chat/completions`, `/v1/completions`, `/v1/responses` (suffix-matched so proxy base URLs with path prefixes still qualify). Embeddings/audio/files are untouched: their engines don't prefix-cache and may reject unknown fields. Non-object JSON, trailing data, and non-JSON bodies pass through byte-identical, and bodies are decoded with `UseNumber` so int64-range values (e.g. `seed`) survive the re-marshal — same handling as the router's `saltProxiedBody`.

## Tests (mutation-verified)

Each protective behavior was checked to actually bite by re-introducing the mutation and confirming the suite fails:

- dropping the no-clobber check → `TestUserCacheSecretTransportNeverClobbers` fails
- dropping the endpoint allowlist → `TestUserCacheSecretTransportSkipsIneligibleRequests` fails
- `GetBody` replaying the caller's original (pre-injection) bytes → `TestUserCacheSecretTransportInjects` fails

Also covered: resolution precedence incl. both empty-disable forms, generate-and-persist (0600, stable across resolutions), adoption of an existing file (trailing-newline tolerant), blank-file rewrite, no-home and home-not-a-directory fallbacks, number precision, and an end-to-end test driving the real `openai-go` client through the transport to a local server — proving the field lands in SDK-serialized requests and that a per-request `WithJSONSet` wins over the client-level secret.

`TestHTTPClient` (pre-existing) pins the transport stack shape and was updated for the new layer.

## Release-order note

**Do not tag a release containing this until the router side (tinfoilsh/confidential-model-router#387) is deployed.** Today's production router forwards unknown body fields to the engines; #387 makes the router strip `user_cache_secret` unconditionally (flag on or off). Once it's deployed, this SDK is safe to release, and mode-2 adoption becomes visible on the router's `router_cache_salt_injections_total{mode="user"}` share.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-user prompt cache scoping to the Go SDK by provisioning and injecting a `user_cache_secret` into eligible requests, isolating prefix-cache hits per user within a tenant and keeping the field enclave-only. Also adds a strict JSON guard so malformed bodies with trailing `}` or `]` are forwarded untouched; do not release until the router strip for `user_cache_secret` is deployed.

- **New Features**
  - Provision via `WithUserCacheSecret(secret)`, `TINFOIL_USER_CACHE_SECRET`, or auto-generate and persist a 256‑bit secret at `~/.tinfoil/user_cache_secret` (0600; dir 0700); empty values disable provisioning; falls back to in-memory with a one-time warning if persistence fails.
  - Injects above EHBP/pinned TLS and below host-binding; retries replay injected bytes. Precedence: body field > client option > env > generated; never overwrites an existing field. Multi-user servers should set per-request secrets via `option.WithJSONSet("user_cache_secret", secret)`.
  - Only injects into `/v1/chat/completions`, `/v1/completions`, `/v1/responses`; non-JSON or non-object bodies pass through; preserves number precision.

- **Bug Fixes**
  - Rejects bodies with extra top-level bytes (e.g., trailing `}` or `]`) before injection, matching the router’s guard and preventing silent re-marshal of malformed requests.

<sup>Written for commit a03a06e1aadb12e58fe5bd7b3182f74df95bdcfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-go/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

