### PR TITLE
sigstore: require exactly one DSSE signature (SPEC §5.2)

### DIFF
--- a/verifier/sigstore/bundle_format.go
+++ b/verifier/sigstore/bundle_format.go
@@ -20,3 +20,22 @@ func rejectLegacyBundleFormat(b *protobundle.Bundle) error {
 	}
 	return nil
 }
+
+// requireExactlyOneDSSESignature enforces the Sigstore bundle rule (SPEC §5.2)
+// that a DSSE-envelope bundle carries exactly one signature. sigstore-go rejects
+// the empty-signatures case only indirectly — an emptied signatures array
+// changes the envelope and breaks the Rekor tlog binding, so it fails as a
+// transparency-log mismatch rather than a signature-count error. We check the
+// count directly and early so both the empty (0) and duplicate (>1) cases fail
+// with a clear, uniform reason, matching tinfoil-rs/-py/-js.
+func requireExactlyOneDSSESignature(b *protobundle.Bundle) error {
+	env := b.GetDsseEnvelope()
+	if env == nil {
+		// Not a DSSE-envelope bundle (e.g. message signature); nothing to check.
+		return nil
+	}
+	if n := len(env.GetSignatures()); n != 1 {
+		return fmt.Errorf("DSSE envelope must have exactly one signature, got %d", n)
+	}
+	return nil
+}

--- a/verifier/sigstore/sigstore.go
+++ b/verifier/sigstore/sigstore.go
@@ -74,6 +74,9 @@ func (c *Client) VerifyBundle(bundleJSON []byte, repo, hexDigest string) (*verif
 	if err := rejectLegacyBundleFormat(b.Bundle); err != nil {
 		return nil, err
 	}
+	if err := requireExactlyOneDSSESignature(b.Bundle); err != nil {
+		return nil, err
+	}
 
 	verifier, err := verify.NewSignedEntityVerifier(
 		c.trustRoot,


### PR DESCRIPTION
An empty-signatures DSSE envelope was rejected only indirectly (the emptied signatures array breaks the Rekor tlog leaf-hash binding, so it failed as a transparency-log mismatch). Add requireExactlyOneDSSESignature, called after bundle parse in VerifyBundle, so both the empty (0) and duplicate (>1) cases fail with a clear signature-count error — matching tinfoil-rs/-py/-js and the Sigstore bundle format's "exactly one signature" rule.

Stacked on fix/sigstore-reject-legacy-bundle (shares bundle_format.go).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require exactly one DSSE signature in Sigstore bundles (SPEC §5.2). Verification now fails early with a clear signature-count error for 0 or >1 signatures, aligning with tinfoil-rs/-py/-js.

- **Bug Fixes**
  - Add requireExactlyOneDSSESignature; run after parsing in VerifyBundle.
  - Error: "DSSE envelope must have exactly one signature, got N".
  - Only applies to DSSE envelopes; other bundle types unchanged.

<sup>Written for commit 45729cd44072cc254c66ac7b7575952d7bc0efed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-go/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

