### PR TITLE
Feat/v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/charmbracelet/log v1.0.0
-	github.com/google/go-sev-guest v0.14.1
+	github.com/google/go-sev-guest v0.15.0
 	github.com/google/go-tdx-guest v0.3.1
 	github.com/openai/openai-go/v3 v3.16.0
 	github.com/sigstore/protobuf-specs v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/google/go-configfs-tsm v0.2.2 h1:YnJ9rXIOj5BYD7/0DNnzs8AOp7UcvjfTvt21
 github.com/google/go-configfs-tsm v0.2.2/go.mod h1:EL1GTDFMb5PZQWDviGfZV9n87WeGTR/JUg13RfwkgRo=
 github.com/google/go-containerregistry v0.21.6 h1:T+yqQIlJXKrM98Om4DlW3GoWQAmhZuLMwoDOvVrtiUM=
 github.com/google/go-containerregistry v0.21.6/go.mod h1:U7MMSBIJynke2MVQrQk19NP9k/uQsGz/h0amIFSHMbo=
-github.com/google/go-sev-guest v0.14.1 h1:j/DXy9jk1qSW/dEV9vDiQnhAVFD1zqnWNVu6p1J0Jgo=
-github.com/google/go-sev-guest v0.14.1/go.mod h1:SK9vW+uyfuzYdVN0m8BShL3OQCtXZe/JPF7ZkpD3760=
+github.com/google/go-sev-guest v0.15.0 h1:Xzfut5mbhcVb7TyPiyc5PolLUzdai7VH3QpyvXwcW9Y=
+github.com/google/go-sev-guest v0.15.0/go.mod h1:SK9vW+uyfuzYdVN0m8BShL3OQCtXZe/JPF7ZkpD3760=
 github.com/google/go-tdx-guest v0.3.1 h1:gl0KvjdsD4RrJzyLefDOvFOUH3NAJri/3qvaL5m83Iw=
 github.com/google/go-tdx-guest v0.3.1/go.mod h1:/rc3d7rnPykOPuY8U9saMyEps0PZDThLk/RygXm04nE=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=

--- a/verifier/attestation/sev.go
+++ b/verifier/attestation/sev.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-sev-guest/verify/trust"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"github.com/tinfoilsh/tinfoil-go/verifier/policy"
 	"github.com/tinfoilsh/tinfoil-go/verifier/util"
 )
 
@@ -34,9 +35,8 @@ func (*getter) Get(targetURL string) ([]byte, error) {
 	if strings.HasSuffix(u.Path, "/cert_chain") {
 		if u.Path == "/vcek/v1/Genoa/cert_chain" {
 			return vcekGenoaCertChain, nil
-		} else {
-			return nil, fmt.Errorf("cert_chain is not supported")
 		}
+		return nil, fmt.Errorf("cert_chain is not supported")
 	}
 
 	u.Host = "kds-proxy.tinfoil.sh"
@@ -51,7 +51,24 @@ var (
 	_ trust.HTTPSGetter = &getter{}
 )
 
-func verifySevReport(attestationDoc string, isCompressed bool, vcekDER []byte) (*sevsnp.Report, error) {
+// sevProductFromReport derives the SEV product from the report's CPUID
+// family/model/stepping field (present in report version 3+). Reports
+// without the field (version 2) predate Turin and are treated as Genoa.
+func sevProductFromReport(report *sevsnp.Report) *sevsnp.SevProduct {
+	if fms := report.GetCpuid1EaxFms(); fms != 0 {
+		return abi.SevProductFromCpuid1Eax(fms)
+	}
+	return &sevsnp.SevProduct{
+		Name:            sevsnp.SevProduct_SEV_PRODUCT_GENOA,
+		MachineStepping: &wrapperspb.UInt32Value{Value: uint32(0)},
+	}
+}
+
+// verifySevSignature decodes a report, derives its product, and verifies the
+// report signature under the AMD roots (VCEK provided or fetched from KDS).
+// It performs no policy validation; callers must validate the returned
+// attestation before trusting any report field.
+func verifySevSignature(attestationDoc string, isCompressed bool, vcekDER []byte) (*sevsnp.Attestation, error) {
 	attDocBytes, err := base64.StdEncoding.DecodeString(attestationDoc)
 	if err != nil {
 		return nil, err
@@ -64,17 +81,14 @@ func verifySevReport(attestationDoc string, isCompressed bool, vcekDER []byte) (
 		}
 	}
 
-	opts := verify.DefaultOptions()
-	opts.Getter = &getter{}
-	opts.Product = &sevsnp.SevProduct{
-		Name:            sevsnp.SevProduct_SEV_PRODUCT_GENOA,
-		MachineStepping: &wrapperspb.UInt32Value{Value: uint32(0)},
-	}
-
 	parsedReport, err := abi.ReportToProto(attDocBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse report: %w", err)
 	}
+
+	opts := verify.DefaultOptions()
+	opts.Getter = &getter{}
+	opts.Product = sevProductFromReport(parsedReport)
 
 	var attestation *sevsnp.Attestation
 	if vcekDER != nil {
@@ -95,6 +109,47 @@ func verifySevReport(attestationDoc string, isCompressed bool, vcekDER []byte) (
 	}
 
 	if err := verify.SnpAttestation(attestation, opts); err != nil {
+		return nil, err
+	}
+	return attestation, nil
+}
+
+// verifySevReportWithEndorsements verifies a report signature, extracts the
+// authenticated platform identity, looks up the machine's endorsed policy in
+// the platform-endorsements artifact, and validates the report against that
+// policy. Returns the verified report and the matched policy name. A machine
+// absent from the artifact fails verification.
+func verifySevReportWithEndorsements(attestationDoc string, isCompressed bool, vcekDER []byte, endorsements *policy.Artifact) (*sevsnp.Report, string, error) {
+	attestation, err := verifySevSignature(attestationDoc, isCompressed, vcekDER)
+	if err != nil {
+		return nil, "", err
+	}
+	report := attestation.GetReport()
+
+	identity, err := policy.SEVIdentity(report.GetChipId())
+	if err != nil {
+		return nil, "", err
+	}
+	policyName, machinePolicy, err := endorsements.PolicyFor(identity, policy.PlatformSEVSNP)
+	if err != nil {
+		return nil, "", err
+	}
+
+	productLine := kds.ProductLine(attestation.GetProduct())
+	valOpts, err := machinePolicy.SEVSNP.SEVOptions(productLine)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := validate.SnpAttestation(attestation, valOpts); err != nil {
+		return nil, "", err
+	}
+
+	return report, policyName, nil
+}
+
+func verifySevReport(attestationDoc string, isCompressed bool, vcekDER []byte) (*sevsnp.Report, error) {
+	attestation, err := verifySevSignature(attestationDoc, isCompressed, vcekDER)
+	if err != nil {
 		return nil, err
 	}
 
@@ -148,7 +203,7 @@ func verifySevReport(attestationDoc string, isCompressed bool, vcekDER []byte) (
 		return nil, err
 	}
 
-	return parsedReport, nil
+	return attestation.GetReport(), nil
 }
 
 func verifySevAttestationV2(attestationDoc string) (*Verification, error) {

--- a/verifier/attestation/sev_endorsements_test.go
+++ b/verifier/attestation/sev_endorsements_test.go
@@ -1,0 +1,74 @@
+package attestation
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tinfoilsh/tinfoil-go/verifier/policy"
+)
+
+// TestVerifySevReportWithEndorsements runs the full endorsement-enforced
+// verification against a live-captured production report (a Genoa machine
+// endorsed in the artifact) plus the real machines/policies data. Skips when
+// the workspace fixture directory is not present.
+func TestVerifySevReportWithEndorsements(t *testing.T) {
+	root := filepath.Join("..", "..", "..", "attestation-samples", "inference.tinfoil.sh")
+	freshBytes, err := os.ReadFile(filepath.Join(root, "fresh.json"))
+	if os.IsNotExist(err) {
+		t.Skip("live inference fixture not collected")
+	}
+	require.NoError(t, err)
+	materialBytes, err := os.ReadFile(filepath.Join(root, "attestation-material.json"))
+	require.NoError(t, err)
+
+	var fresh struct {
+		CPU struct {
+			Platform string `json:"platform"`
+			Report   string `json:"report"`
+		} `json:"cpu"`
+	}
+	require.NoError(t, json.Unmarshal(freshBytes, &fresh))
+	require.Equal(t, "sev-snp", fresh.CPU.Platform)
+
+	var material struct {
+		Collateral struct {
+			CPUVendor struct {
+				SEVSNP struct {
+					VCEKDERBase64 string `json:"vcek_der_base64"`
+				} `json:"sev_snp"`
+			} `json:"cpu_vendor"`
+		} `json:"collateral"`
+	}
+	require.NoError(t, json.Unmarshal(materialBytes, &material))
+	vcekDER := mustBase64(t, material.Collateral.CPUVendor.SEVSNP.VCEKDERBase64)
+
+	artifactBytes, err := os.ReadFile(filepath.Join("..", "policy", "testdata", "platform-endorsements.json"))
+	require.NoError(t, err)
+	artifact, err := policy.ParseArtifact(artifactBytes)
+	require.NoError(t, err)
+
+	report, policyName, err := verifySevReportWithEndorsements(fresh.CPU.Report, false, vcekDER, artifact)
+	require.NoError(t, err)
+	assert.Equal(t, "amd-genoa-prod", policyName)
+	assert.NotEmpty(t, report.Measurement)
+
+	// The same quote must fail against an artifact that does not endorse
+	// this machine.
+	unendorsed := *artifact
+	unendorsed.Machines = map[string]string{}
+	_, _, err = verifySevReportWithEndorsements(fresh.CPU.Report, false, vcekDER, &unendorsed)
+	assert.ErrorContains(t, err, "not endorsed")
+}
+
+func mustBase64(t *testing.T, s string) []byte {
+	t.Helper()
+	decoded, err := base64.StdEncoding.DecodeString(s)
+	require.NoError(t, err)
+	return decoded
+}

--- a/verifier/policy/artifact.go
+++ b/verifier/policy/artifact.go
@@ -1,0 +1,208 @@
+// Package policy parses the Sigstore-signed platform-endorsements artifact
+// (predicate https://tinfoil.sh/predicate/platform-endorsements/v1) and turns
+// its appraisal policies into enforceable validation options.
+//
+// The artifact maps hardware identifiers to named policies:
+//   - AMD SEV-SNP machines are keyed by the 64-byte CHIP_ID report field
+//     (128 lowercase hex chars; Turin hardware IDs are zero-padded)
+//   - Intel TDX machines are keyed by the 16-byte PPID (32 lowercase hex
+//     chars) carried in the PCK leaf certificate of every quote
+//
+// Parsing is fail-closed: unknown JSON fields, malformed identifiers,
+// dangling policy references, or platform mismatches are errors. A policy
+// that cannot be fully enforced must never be partially applied.
+package policy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"regexp"
+)
+
+// ArtifactFormat is the required format URI of the platform-endorsements artifact.
+const ArtifactFormat = "https://tinfoil.sh/predicate/platform-endorsements/v1"
+
+const (
+	// PlatformSEVSNP labels AMD SEV-SNP policies.
+	PlatformSEVSNP = "sev-snp"
+	// PlatformTDX labels Intel TDX policies.
+	PlatformTDX = "tdx"
+
+	sevIdentifierHexLen = 128
+	tdxIdentifierHexLen = 32
+)
+
+var lowerHexRE = regexp.MustCompile(`^[0-9a-f]+$`)
+
+// Artifact is the parsed platform-endorsements document.
+type Artifact struct {
+	Format       string                         `json:"format"`
+	Measurements map[string]PlatformMeasurement `json:"measurements"`
+	Machines     map[string]string              `json:"machines"`
+	Policies     map[string]Policy              `json:"policies"`
+}
+
+// PlatformMeasurement is one TDX platform configuration's expected registers.
+type PlatformMeasurement struct {
+	MRTD  string `json:"mrtd"`
+	RTMR0 string `json:"rtmr0"`
+}
+
+// Policy is a named appraisal policy. Exactly one platform block is set,
+// matching Platform.
+type Policy struct {
+	Platform string        `json:"platform"`
+	SEVSNP   *SEVSNPPolicy `json:"sev_snp,omitempty"`
+	TDX      *TDXPolicy    `json:"tdx,omitempty"`
+}
+
+// SEVSNPPolicy is the standard SEV-SNP policy block.
+type SEVSNPPolicy struct {
+	MinimumBuild              uint8       `json:"minimum_build"`
+	MinimumAPIVersion         string      `json:"minimum_api_version"`
+	MinimumGuestSVN           uint32      `json:"minimum_guest_svn"`
+	MinimumTCB                TCB         `json:"minimum_tcb"`
+	MinimumLaunchTCB          TCB         `json:"minimum_launch_tcb"`
+	GuestPolicy               GuestPolicy `json:"guest_policy"`
+	PlatformInfo              SNPPlatform `json:"platform_info"`
+	PermitProvisionalFirmware bool        `json:"permit_provisional_firmware"`
+	VMPL                      *int        `json:"vmpl"`
+}
+
+// TCB holds AMD security patch levels. FmcSpl is present only for Turin
+// (family 1Ah) policies, whose TCB_VERSION layout differs from Genoa.
+type TCB struct {
+	FmcSpl   *uint8 `json:"fmc_spl,omitempty"`
+	BlSpl    uint8  `json:"bl_spl"`
+	TeeSpl   uint8  `json:"tee_spl"`
+	SnpSpl   uint8  `json:"snp_spl"`
+	UcodeSpl uint8  `json:"ucode_spl"`
+}
+
+// GuestPolicy mirrors the SNP guest policy bits enforced at verification.
+type GuestPolicy struct {
+	Debug        bool `json:"debug"`
+	SMT          bool `json:"smt"`
+	MigrateMA    bool `json:"migrate_ma"`
+	SingleSocket bool `json:"single_socket"`
+}
+
+// SNPPlatform mirrors the SNP PLATFORM_INFO expectations.
+type SNPPlatform struct {
+	SMTEnabled           bool `json:"smt_enabled"`
+	TSMEEnabled          bool `json:"tsme_enabled"`
+	ECCEnabled           bool `json:"ecc_enabled"`
+	RAPLDisabled         bool `json:"rapl_disabled"`
+	CiphertextHidingDRAM bool `json:"ciphertext_hiding_dram"`
+}
+
+// TDXPolicy is the standard Intel TDX policy block.
+type TDXPolicy struct {
+	QEVendorID                     string   `json:"qe_vendor_id"`
+	MinimumQESVN                   uint16   `json:"minimum_qe_svn"`
+	MinimumPCESVN                  uint16   `json:"minimum_pce_svn"`
+	MinimumTEETCBSVN               string   `json:"minimum_tee_tcb_svn"`
+	AcceptedMRSeams                []string `json:"accepted_mr_seams"`
+	TDAttributes                   string   `json:"td_attributes"`
+	XFAM                           string   `json:"xfam"`
+	MRConfigIDZero                 bool     `json:"mr_config_id_zero"`
+	MROwnerZero                    bool     `json:"mr_owner_zero"`
+	MROwnerConfigZero              bool     `json:"mr_owner_config_zero"`
+	MinimumTCBEvaluationDataNumber int      `json:"minimum_tcb_evaluation_data_number"`
+	PlatformMeasurements           []string `json:"platform_measurements"`
+}
+
+// ParseArtifact strictly decodes and validates a platform-endorsements
+// artifact. Unknown fields anywhere in the document are rejected.
+//
+// Duplicate JSON member names are NOT detected (Go's decoder keeps the last
+// value): the artifact is Sigstore-signed and its publishing pipeline
+// rejects duplicates before signing, so auditing "one machine, one policy"
+// is the publisher's and auditors' job, not the client verifier's.
+func ParseArtifact(data []byte) (*Artifact, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var a Artifact
+	if err := dec.Decode(&a); err != nil {
+		return nil, fmt.Errorf("parsing platform-endorsements artifact: %w", err)
+	}
+	if dec.More() {
+		return nil, fmt.Errorf("trailing data after platform-endorsements artifact")
+	}
+	if a.Format != ArtifactFormat {
+		return nil, fmt.Errorf("unsupported artifact format %q", a.Format)
+	}
+	if err := a.validate(); err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+func (a *Artifact) validate() error {
+	for name, p := range a.Policies {
+		switch p.Platform {
+		case PlatformSEVSNP:
+			if p.SEVSNP == nil || p.TDX != nil {
+				return fmt.Errorf("policy %q: platform sev-snp requires exactly the sev_snp block", name)
+			}
+		case PlatformTDX:
+			if p.TDX == nil || p.SEVSNP != nil {
+				return fmt.Errorf("policy %q: platform tdx requires exactly the tdx block", name)
+			}
+			for _, ref := range p.TDX.PlatformMeasurements {
+				if _, ok := a.Measurements[ref]; !ok {
+					return fmt.Errorf("policy %q: platform_measurements ref %q not in measurements", name, ref)
+				}
+			}
+		default:
+			return fmt.Errorf("policy %q: unsupported platform %q", name, p.Platform)
+		}
+	}
+
+	for identifier, policyName := range a.Machines {
+		p, ok := a.Policies[policyName]
+		if !ok {
+			return fmt.Errorf("machine %s...: unknown policy %q", truncID(identifier), policyName)
+		}
+		if !lowerHexRE.MatchString(identifier) {
+			return fmt.Errorf("machine %s...: identifier is not lowercase hex", truncID(identifier))
+		}
+		switch p.Platform {
+		case PlatformSEVSNP:
+			if len(identifier) != sevIdentifierHexLen {
+				return fmt.Errorf("machine %s...: sev-snp identifier must be %d hex chars, got %d",
+					truncID(identifier), sevIdentifierHexLen, len(identifier))
+			}
+		case PlatformTDX:
+			if len(identifier) != tdxIdentifierHexLen {
+				return fmt.Errorf("machine %s...: tdx identifier must be %d hex chars, got %d",
+					truncID(identifier), tdxIdentifierHexLen, len(identifier))
+			}
+		}
+	}
+	return nil
+}
+
+// PolicyFor looks up the appraisal policy for an authenticated platform
+// identifier (lowercase hex) extracted from verified evidence, and asserts
+// the policy's platform matches the evidence platform. An identifier absent
+// from the machines map is an error: the machine is not endorsed.
+func (a *Artifact) PolicyFor(identifierHex string, platform string) (string, *Policy, error) {
+	name, ok := a.Machines[identifierHex]
+	if !ok {
+		return "", nil, fmt.Errorf("platform identifier %s... is not endorsed", truncID(identifierHex))
+	}
+	p := a.Policies[name]
+	if p.Platform != platform {
+		return "", nil, fmt.Errorf("policy %q is for platform %q, evidence is %q", name, p.Platform, platform)
+	}
+	return name, &p, nil
+}
+
+func truncID(id string) string {
+	if len(id) > 16 {
+		return id[:16]
+	}
+	return id
+}

--- a/verifier/policy/artifact.go
+++ b/verifier/policy/artifact.go
@@ -70,8 +70,9 @@ type SEVSNPPolicy struct {
 	VMPL                      *int        `json:"vmpl"`
 }
 
-// TCB holds AMD security patch levels. FmcSpl is present only for Turin
-// (family 1Ah) policies, whose TCB_VERSION layout differs from Genoa.
+// TCB holds AMD security patch levels. FmcSpl (family 1Ah / Turin only) is
+// accepted for forward-compatibility but Turin verification is not yet
+// supported (see MASTER_PLAN.md).
 type TCB struct {
 	FmcSpl   *uint8 `json:"fmc_spl,omitempty"`
 	BlSpl    uint8  `json:"bl_spl"`

--- a/verifier/policy/identity.go
+++ b/verifier/policy/identity.go
@@ -1,0 +1,68 @@
+package policy
+
+import (
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+
+	tdxpb "github.com/google/go-tdx-guest/proto/tdx"
+
+	"github.com/google/go-tdx-guest/pcs"
+)
+
+// SEVIdentity returns the machines-map lookup key for a verified SEV-SNP
+// report's CHIP_ID field. The field is always 64 bytes; Turin hardware
+// delivers its 8-byte hwID zero-padded, which is exactly the endorsed form,
+// so no product-specific handling is needed.
+func SEVIdentity(chipID []byte) (string, error) {
+	if len(chipID) != 64 {
+		return "", fmt.Errorf("SEV CHIP_ID must be 64 bytes, got %d", len(chipID))
+	}
+	return hex.EncodeToString(chipID), nil
+}
+
+// TDXIdentity extracts the machines-map lookup key (the 16-byte PPID) from
+// the PCK leaf certificate embedded in a verified TDX quote. The PPID is
+// authenticated because the PCK chain is validated up to the Intel SGX root
+// during quote verification; callers must only invoke this after
+// verification succeeds.
+func TDXIdentity(quote *tdxpb.QuoteV4) (string, error) {
+	leaf, err := pckLeafCertificate(quote)
+	if err != nil {
+		return "", err
+	}
+	ext, err := pcs.PckCertificateExtensions(leaf)
+	if err != nil {
+		return "", fmt.Errorf("parsing PCK certificate extensions: %w", err)
+	}
+	ppid, err := hex.DecodeString(ext.PPID)
+	if err != nil || len(ppid) != 16 {
+		return "", fmt.Errorf("PCK certificate carries malformed PPID %q", ext.PPID)
+	}
+	// Re-encode rather than returning ext.PPID: the machines-map lookup is
+	// case-sensitive and this guarantees canonical lowercase hex regardless
+	// of the upstream parser's encoding.
+	return hex.EncodeToString(ppid), nil
+}
+
+func pckLeafCertificate(quote *tdxpb.QuoteV4) (*x509.Certificate, error) {
+	signedData := quote.GetSignedData()
+	if signedData == nil {
+		return nil, fmt.Errorf("quote has no signed data")
+	}
+	chainData := signedData.GetCertificationData().GetQeReportCertificationData().GetPckCertificateChainData()
+	if chainData == nil || len(chainData.GetPckCertChain()) == 0 {
+		return nil, fmt.Errorf("quote carries no PCK certificate chain (certification data type 5)")
+	}
+
+	block, _ := pem.Decode(chainData.GetPckCertChain())
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("PCK certificate chain is not PEM")
+	}
+	leaf, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing PCK leaf certificate: %w", err)
+	}
+	return leaf, nil
+}

--- a/verifier/policy/policy_test.go
+++ b/verifier/policy/policy_test.go
@@ -1,7 +1,6 @@
 package policy
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"os"
 	"strings"
@@ -91,42 +90,18 @@ func TestSEVOptionsGenoa(t *testing.T) {
 	assert.True(t, opts.PlatformInfo.TSMEEnabled)
 }
 
-func TestSEVOptionsTurin(t *testing.T) {
+// Turin (family 1Ah) is intentionally unsupported by the v3 verifier for now
+// (see MASTER_PLAN.md); SEVOptions must reject any non-Genoa product line.
+func TestSEVOptionsRejectsNonGenoa(t *testing.T) {
 	a := loadFixture(t)
 	_, p, err := a.PolicyFor(box2TurinID, PlatformSEVSNP)
 	require.NoError(t, err)
 
-	opts, err := p.SEVSNP.SEVOptions(ProductTurin)
-	require.NoError(t, err)
-	// Turin TCB floors are enforced via CheckTurinTCB, not library options.
-	assert.Zero(t, opts.MinimumTCB.UcodeSpl)
-
-	// A Turin policy fed to the Genoa translation must fail (fmc_spl set).
-	_, err = p.SEVSNP.SEVOptions(ProductGenoa)
-	assert.ErrorContains(t, err, "fmc_spl")
+	_, err = p.SEVSNP.SEVOptions("Turin")
+	assert.ErrorContains(t, err, "unsupported SEV product line")
 
 	_, err = p.SEVSNP.SEVOptions("Milan")
 	assert.ErrorContains(t, err, "unsupported SEV product line")
-}
-
-func TestCheckTurinTCB(t *testing.T) {
-	a := loadFixture(t)
-	_, p, err := a.PolicyFor(box2TurinID, PlatformSEVSNP)
-	require.NoError(t, err)
-
-	// box2's real reported TCB bytes as they appear in the report (little endian).
-	raw := binary.LittleEndian.Uint64(mustHex(t, "0101010400000052"))
-	decomposed := DecomposeTurinTCB(raw)
-	assert.Equal(t, uint8(1), decomposed.FmcSpl)
-	assert.Equal(t, uint8(1), decomposed.BlSpl)
-	assert.Equal(t, uint8(1), decomposed.TeeSpl)
-	assert.Equal(t, uint8(4), decomposed.SnpSpl)
-	assert.Equal(t, uint8(82), decomposed.UcodeSpl)
-
-	require.NoError(t, p.SEVSNP.CheckTurinTCB("reported_tcb", raw, p.SEVSNP.MinimumTCB))
-
-	older := binary.LittleEndian.Uint64(mustHex(t, "0101010400000051")) // ucode 81 < floor 82
-	assert.ErrorContains(t, p.SEVSNP.CheckTurinTCB("reported_tcb", older, p.SEVSNP.MinimumTCB), "below policy floor")
 }
 
 func TestTDXOptionsAndChecks(t *testing.T) {

--- a/verifier/policy/policy_test.go
+++ b/verifier/policy/policy_test.go
@@ -1,0 +1,168 @@
+package policy
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// Real production identifiers (public by design in the endorsement artifact).
+	box3GenoaID = "cfdce31f5c40fc4e6eef803f6b5ed77e88b22603a91337bacab58446ab05fb8ef7bb5221611dced98dfa01d1eac114ca9a7952c262705977a36d81b0a53f856e"
+	box2TurinID = "6bb1229b7692b7100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	inf7PPID    = "3b064a0f58d5dd3688780aeb40e0b5d2"
+)
+
+func loadFixture(t *testing.T) *Artifact {
+	t.Helper()
+	data, err := os.ReadFile("testdata/platform-endorsements.json")
+	require.NoError(t, err)
+	a, err := ParseArtifact(data)
+	require.NoError(t, err)
+	return a
+}
+
+func TestParseArtifactFixture(t *testing.T) {
+	a := loadFixture(t)
+	assert.Len(t, a.Machines, 12)
+	assert.Len(t, a.Policies, 5)
+	assert.Len(t, a.Measurements, 16)
+}
+
+func TestParseArtifactFailClosed(t *testing.T) {
+	data, err := os.ReadFile("testdata/platform-endorsements.json")
+	require.NoError(t, err)
+
+	unknownField := strings.Replace(string(data), `"machines"`, `"surprise": {}, "machines"`, 1)
+	_, err = ParseArtifact([]byte(unknownField))
+	assert.ErrorContains(t, err, "surprise")
+
+	wrongFormat := strings.Replace(string(data), "platform-endorsements/v1", "platform-endorsements/v9", 1)
+	_, err = ParseArtifact([]byte(wrongFormat))
+	assert.ErrorContains(t, err, "unsupported artifact format")
+
+	danglingRef := strings.Replace(string(data), `"amd-genoa-prod"`, `"no-such-policy"`, 1)
+	_, err = ParseArtifact([]byte(danglingRef))
+	assert.ErrorContains(t, err, "unknown policy")
+}
+
+func TestPolicyLookup(t *testing.T) {
+	a := loadFixture(t)
+
+	name, p, err := a.PolicyFor(box2TurinID, PlatformSEVSNP)
+	require.NoError(t, err)
+	assert.Equal(t, "amd-turin-prod", name)
+	require.NotNil(t, p.SEVSNP)
+
+	name, p, err = a.PolicyFor(inf7PPID, PlatformTDX)
+	require.NoError(t, err)
+	assert.Equal(t, "tdx-h200-prod", name)
+	require.NotNil(t, p.TDX)
+
+	// Platform mismatch: TDX identifier presented as SEV evidence.
+	_, _, err = a.PolicyFor(inf7PPID, PlatformSEVSNP)
+	assert.ErrorContains(t, err, "is for platform")
+
+	// Unknown machine: unconditional rejection.
+	_, _, err = a.PolicyFor(strings.Repeat("ab", 64), PlatformSEVSNP)
+	assert.ErrorContains(t, err, "not endorsed")
+}
+
+func TestSEVOptionsGenoa(t *testing.T) {
+	a := loadFixture(t)
+	_, p, err := a.PolicyFor(box3GenoaID, PlatformSEVSNP)
+	require.NoError(t, err)
+
+	opts, err := p.SEVSNP.SEVOptions(ProductGenoa)
+	require.NoError(t, err)
+	assert.Equal(t, uint8(21), opts.MinimumBuild)
+	assert.Equal(t, uint16(1<<8|55), opts.MinimumVersion)
+	assert.Equal(t, uint8(7), opts.MinimumTCB.BlSpl)
+	assert.Equal(t, uint8(14), opts.MinimumTCB.SnpSpl)
+	assert.Equal(t, uint8(72), opts.MinimumTCB.UcodeSpl)
+	assert.True(t, opts.GuestPolicy.SMT)
+	assert.False(t, opts.GuestPolicy.Debug)
+	require.NotNil(t, opts.PlatformInfo)
+	assert.True(t, opts.PlatformInfo.TSMEEnabled)
+}
+
+func TestSEVOptionsTurin(t *testing.T) {
+	a := loadFixture(t)
+	_, p, err := a.PolicyFor(box2TurinID, PlatformSEVSNP)
+	require.NoError(t, err)
+
+	opts, err := p.SEVSNP.SEVOptions(ProductTurin)
+	require.NoError(t, err)
+	// Turin TCB floors are enforced via CheckTurinTCB, not library options.
+	assert.Zero(t, opts.MinimumTCB.UcodeSpl)
+
+	// A Turin policy fed to the Genoa translation must fail (fmc_spl set).
+	_, err = p.SEVSNP.SEVOptions(ProductGenoa)
+	assert.ErrorContains(t, err, "fmc_spl")
+
+	_, err = p.SEVSNP.SEVOptions("Milan")
+	assert.ErrorContains(t, err, "unsupported SEV product line")
+}
+
+func TestCheckTurinTCB(t *testing.T) {
+	a := loadFixture(t)
+	_, p, err := a.PolicyFor(box2TurinID, PlatformSEVSNP)
+	require.NoError(t, err)
+
+	// box2's real reported TCB bytes as they appear in the report (little endian).
+	raw := binary.LittleEndian.Uint64(mustHex(t, "0101010400000052"))
+	decomposed := DecomposeTurinTCB(raw)
+	assert.Equal(t, uint8(1), decomposed.FmcSpl)
+	assert.Equal(t, uint8(1), decomposed.BlSpl)
+	assert.Equal(t, uint8(1), decomposed.TeeSpl)
+	assert.Equal(t, uint8(4), decomposed.SnpSpl)
+	assert.Equal(t, uint8(82), decomposed.UcodeSpl)
+
+	require.NoError(t, p.SEVSNP.CheckTurinTCB("reported_tcb", raw, p.SEVSNP.MinimumTCB))
+
+	older := binary.LittleEndian.Uint64(mustHex(t, "0101010400000051")) // ucode 81 < floor 82
+	assert.ErrorContains(t, p.SEVSNP.CheckTurinTCB("reported_tcb", older, p.SEVSNP.MinimumTCB), "below policy floor")
+}
+
+func TestTDXOptionsAndChecks(t *testing.T) {
+	a := loadFixture(t)
+	_, p, err := a.PolicyFor(inf7PPID, PlatformTDX)
+	require.NoError(t, err)
+
+	opts, err := p.TDX.TDXOptions()
+	require.NoError(t, err)
+	assert.Equal(t, mustHex(t, "939a7233f79c4ca9940a0db3957f0607"), opts.HeaderOptions.QeVendorID)
+	assert.Equal(t, make([]byte, 48), opts.TdQuoteBodyOptions.MrConfigID)
+	assert.Equal(t, mustHex(t, "0000001000000000"), opts.TdQuoteBodyOptions.TdAttributes)
+
+	require.NotEmpty(t, p.TDX.AcceptedMRSeams)
+	require.NoError(t, p.TDX.CheckMRSeam(mustHex(t, p.TDX.AcceptedMRSeams[0])))
+	assert.ErrorContains(t, p.TDX.CheckMRSeam(make([]byte, 48)), "not in the policy's accepted set")
+
+	ref := p.TDX.PlatformMeasurements[0]
+	m := a.Measurements[ref]
+	require.NoError(t, a.CheckPlatformMeasurement(p.TDX, m.MRTD, m.RTMR0))
+	assert.ErrorContains(t, a.CheckPlatformMeasurement(p.TDX, strings.Repeat("ff", 48), m.RTMR0),
+		"do not match any allowed configuration")
+}
+
+func TestSEVIdentity(t *testing.T) {
+	id, err := SEVIdentity(mustHex(t, box2TurinID))
+	require.NoError(t, err)
+	assert.Equal(t, box2TurinID, id)
+
+	_, err = SEVIdentity([]byte{1, 2, 3})
+	assert.ErrorContains(t, err, "must be 64 bytes")
+}
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	require.NoError(t, err)
+	return b
+}

--- a/verifier/policy/testdata/platform-endorsements.json
+++ b/verifier/policy/testdata/platform-endorsements.json
@@ -1,0 +1,233 @@
+{
+  "format": "https://tinfoil.sh/predicate/platform-endorsements/v1",
+  "machines": {
+    "0635f80268bc84044ebf29398151c789": "tdx-h200-prod",
+    "1af1aa6c1f56037a05849a59b8815cf909583f9ba9ef2f053218c437f33ba183e4e415b039b37f8205250ad15f8b88a0a3add9f4c081c0779a48ed2214378e44": "amd-genoa-prod",
+    "2cc554da2e91064c548f0cb0e305647c": "tdx-b200-prod",
+    "3b064a0f58d5dd3688780aeb40e0b5d2": "tdx-h200-prod",
+    "5eeceeb0e315f66b5a1be5e7aa66727b": "tdx-h200-prod",
+    "6abbf1e5a483bb50f726c9e590d6342a": "tdx-h200-prod",
+    "6bb1229b7692b7100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000": "amd-turin-prod",
+    "709d851f68aaf03947badac9e273a09f": "tdx-h200-prod",
+    "9e2d1e4f1e26f3347d5d7ddd3841f9f4": "tdx-b300-prod",
+    "cfdce31f5c40fc4e6eef803f6b5ed77e88b22603a91337bacab58446ab05fb8ef7bb5221611dced98dfa01d1eac114ca9a7952c262705977a36d81b0a53f856e": "amd-genoa-prod",
+    "de1fce39576e917957bed9c1fff1a8f0": "tdx-h200-prod",
+    "f66463fca6ea06a1537c20b3e02e9076": "tdx-h200-prod"
+  },
+  "measurements": {
+    "extra_large_1d_b200_new": {
+      "mrtd": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      "rtmr0": "101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010"
+    },
+    "extra_large_1d_b300_new": {
+      "mrtd": "010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101",
+      "rtmr0": "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+    },
+    "extra_large_1d_new": {
+      "mrtd": "020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202",
+      "rtmr0": "121212121212121212121212121212121212121212121212121212121212121212121212121212121212121212121212"
+    },
+    "extra_large_2d_b200_new": {
+      "mrtd": "030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303",
+      "rtmr0": "131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313"
+    },
+    "extra_large_2d_b300_new": {
+      "mrtd": "040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404",
+      "rtmr0": "141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414"
+    },
+    "extra_large_2d_new": {
+      "mrtd": "050505050505050505050505050505050505050505050505050505050505050505050505050505050505050505050505",
+      "rtmr0": "151515151515151515151515151515151515151515151515151515151515151515151515151515151515151515151515"
+    },
+    "large_1d_new": {
+      "mrtd": "060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606",
+      "rtmr0": "161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616"
+    },
+    "medium_0d": {
+      "mrtd": "070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707",
+      "rtmr0": "171717171717171717171717171717171717171717171717171717171717171717171717171717171717171717171717"
+    },
+    "medium_0d_new": {
+      "mrtd": "080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808",
+      "rtmr0": "181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818"
+    },
+    "medium_1d": {
+      "mrtd": "090909090909090909090909090909090909090909090909090909090909090909090909090909090909090909090909",
+      "rtmr0": "191919191919191919191919191919191919191919191919191919191919191919191919191919191919191919191919"
+    },
+    "medium_1d_new": {
+      "mrtd": "0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a",
+      "rtmr0": "1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a"
+    },
+    "medium_2d_new": {
+      "mrtd": "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+      "rtmr0": "1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b"
+    },
+    "medium_4d_new": {
+      "mrtd": "0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c",
+      "rtmr0": "1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c"
+    },
+    "mini_0d": {
+      "mrtd": "0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d",
+      "rtmr0": "1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d"
+    },
+    "small_0d": {
+      "mrtd": "0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e",
+      "rtmr0": "1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e"
+    },
+    "small_0d_new": {
+      "mrtd": "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f",
+      "rtmr0": "1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f"
+    }
+  },
+  "policies": {
+    "amd-genoa-prod": {
+      "platform": "sev-snp",
+      "sev_snp": {
+        "guest_policy": {
+          "debug": false,
+          "migrate_ma": false,
+          "single_socket": false,
+          "smt": true
+        },
+        "minimum_api_version": "1.55",
+        "minimum_build": 21,
+        "minimum_guest_svn": 0,
+        "minimum_launch_tcb": {
+          "bl_spl": 7,
+          "snp_spl": 14,
+          "tee_spl": 0,
+          "ucode_spl": 72
+        },
+        "minimum_tcb": {
+          "bl_spl": 7,
+          "snp_spl": 14,
+          "tee_spl": 0,
+          "ucode_spl": 72
+        },
+        "permit_provisional_firmware": false,
+        "platform_info": {
+          "ciphertext_hiding_dram": false,
+          "ecc_enabled": false,
+          "rapl_disabled": false,
+          "smt_enabled": true,
+          "tsme_enabled": true
+        },
+        "vmpl": null
+      }
+    },
+    "amd-turin-prod": {
+      "platform": "sev-snp",
+      "sev_snp": {
+        "guest_policy": {
+          "debug": false,
+          "migrate_ma": false,
+          "single_socket": false,
+          "smt": true
+        },
+        "minimum_api_version": "1.58",
+        "minimum_build": 0,
+        "minimum_guest_svn": 0,
+        "minimum_launch_tcb": {
+          "bl_spl": 1,
+          "fmc_spl": 1,
+          "snp_spl": 4,
+          "tee_spl": 1,
+          "ucode_spl": 82
+        },
+        "minimum_tcb": {
+          "bl_spl": 1,
+          "fmc_spl": 1,
+          "snp_spl": 4,
+          "tee_spl": 1,
+          "ucode_spl": 82
+        },
+        "permit_provisional_firmware": false,
+        "platform_info": {
+          "ciphertext_hiding_dram": false,
+          "ecc_enabled": false,
+          "rapl_disabled": false,
+          "smt_enabled": true,
+          "tsme_enabled": true
+        },
+        "vmpl": null
+      }
+    },
+    "tdx-b200-prod": {
+      "platform": "tdx",
+      "tdx": {
+        "accepted_mr_seams": [
+          "476a2997c62bccc78370913d0a80b956e3721b24272bc66c4d6307ced4be2865c40e26afac75f12df3425b03eb59ea7c"
+        ],
+        "minimum_pce_svn": 0,
+        "minimum_qe_svn": 0,
+        "minimum_tcb_evaluation_data_number": 19,
+        "minimum_tee_tcb_svn": "03010200000000000000000000000000",
+        "mr_config_id_zero": true,
+        "mr_owner_config_zero": true,
+        "mr_owner_zero": true,
+        "platform_measurements": [
+          "extra_large_1d_b200_new",
+          "extra_large_2d_b200_new"
+        ],
+        "qe_vendor_id": "939a7233f79c4ca9940a0db3957f0607",
+        "td_attributes": "0000001000000000",
+        "xfam": "e702060000000000"
+      }
+    },
+    "tdx-b300-prod": {
+      "platform": "tdx",
+      "tdx": {
+        "accepted_mr_seams": [
+          "476a2997c62bccc78370913d0a80b956e3721b24272bc66c4d6307ced4be2865c40e26afac75f12df3425b03eb59ea7c"
+        ],
+        "minimum_pce_svn": 0,
+        "minimum_qe_svn": 0,
+        "minimum_tcb_evaluation_data_number": 19,
+        "minimum_tee_tcb_svn": "03010200000000000000000000000000",
+        "mr_config_id_zero": true,
+        "mr_owner_config_zero": true,
+        "mr_owner_zero": true,
+        "platform_measurements": [
+          "extra_large_1d_b300_new",
+          "extra_large_2d_b300_new"
+        ],
+        "qe_vendor_id": "939a7233f79c4ca9940a0db3957f0607",
+        "td_attributes": "0000001000000000",
+        "xfam": "e702060000000000"
+      }
+    },
+    "tdx-h200-prod": {
+      "platform": "tdx",
+      "tdx": {
+        "accepted_mr_seams": [
+          "7bf063280e94fb051f5dd7b1fc59ce9aac42bb961df8d44b709c9b0ff87a7b4df648657ba6d1189589feab1d5a3c9a9d"
+        ],
+        "minimum_pce_svn": 0,
+        "minimum_qe_svn": 0,
+        "minimum_tcb_evaluation_data_number": 19,
+        "minimum_tee_tcb_svn": "03010200000000000000000000000000",
+        "mr_config_id_zero": true,
+        "mr_owner_config_zero": true,
+        "mr_owner_zero": true,
+        "platform_measurements": [
+          "mini_0d",
+          "small_0d",
+          "small_0d_new",
+          "medium_0d",
+          "medium_0d_new",
+          "medium_1d",
+          "medium_1d_new",
+          "medium_2d_new",
+          "medium_4d_new",
+          "large_1d_new",
+          "extra_large_1d_new",
+          "extra_large_2d_new"
+        ],
+        "qe_vendor_id": "939a7233f79c4ca9940a0db3957f0607",
+        "td_attributes": "0000001000000000",
+        "xfam": "e702060000000000"
+      }
+    }
+  }
+}

--- a/verifier/policy/translate.go
+++ b/verifier/policy/translate.go
@@ -13,27 +13,27 @@ import (
 	tdxvalidate "github.com/google/go-tdx-guest/validate"
 )
 
-// AMD product lines with distinct TCB_VERSION layouts.
-const (
-	ProductGenoa = "Genoa"
-	ProductTurin = "Turin"
-)
+// ProductGenoa is the AMD product line supported by the v3 verifier. Turin
+// (family 1Ah) is intentionally not supported yet (see MASTER_PLAN.md): its
+// TCB_VERSION layout and VCEK HWID differ, and a firmware PLATFORM_INFO
+// discrepancy on our Turin hardware is still under investigation with AMD.
+const ProductGenoa = "Genoa"
 
 // SEVOptions translates the policy block into go-sev-guest validation
-// options for the given product line.
-//
-// For Genoa (family 19h) the TCB floors map onto the library's TCBParts.
-// For Turin (family 1Ah) the TCB_VERSION layout differs (FMC[7:0] BL[15:8]
-// TEE[23:16] SNP[31:24] UCODE[63:56]) and go-sev-guest v0.14.x has no FMC
-// support, so the library TCB floors are left unset and callers MUST enforce
-// TCB via CheckTurinTCB on the verified report's reported and launch TCBs.
+// options for the given product line. Only Genoa (family 19h) is supported.
 func (p *SEVSNPPolicy) SEVOptions(productLine string) (*sevvalidate.Options, error) {
+	if productLine != ProductGenoa {
+		return nil, fmt.Errorf("unsupported SEV product line %q (only %s is supported)", productLine, ProductGenoa)
+	}
 	version, err := parseAPIVersion(p.MinimumAPIVersion)
 	if err != nil {
 		return nil, err
 	}
+	if p.MinimumTCB.FmcSpl != nil || p.MinimumLaunchTCB.FmcSpl != nil {
+		return nil, fmt.Errorf("fmc_spl is not valid for product line %s", productLine)
+	}
 
-	opts := &sevvalidate.Options{
+	return &sevvalidate.Options{
 		GuestPolicy: sevabi.SnpPolicy{
 			Debug:        p.GuestPolicy.Debug,
 			SMT:          p.GuestPolicy.SMT,
@@ -51,70 +51,20 @@ func (p *SEVSNPPolicy) SEVOptions(productLine string) (*sevvalidate.Options, err
 			RAPLDisabled:                p.PlatformInfo.RAPLDisabled,
 			CiphertextHidingDRAMEnabled: p.PlatformInfo.CiphertextHidingDRAM,
 		},
-		VMPL: p.VMPL,
-	}
-
-	switch productLine {
-	case ProductGenoa:
-		if p.MinimumTCB.FmcSpl != nil || p.MinimumLaunchTCB.FmcSpl != nil {
-			return nil, fmt.Errorf("fmc_spl is not valid for product line %s", productLine)
-		}
-		opts.MinimumTCB = kds.TCBParts{
+		MinimumTCB: kds.TCBParts{
 			BlSpl:    p.MinimumTCB.BlSpl,
 			TeeSpl:   p.MinimumTCB.TeeSpl,
 			SnpSpl:   p.MinimumTCB.SnpSpl,
 			UcodeSpl: p.MinimumTCB.UcodeSpl,
-		}
-		opts.MinimumLaunchTCB = kds.TCBParts{
+		},
+		MinimumLaunchTCB: kds.TCBParts{
 			BlSpl:    p.MinimumLaunchTCB.BlSpl,
 			TeeSpl:   p.MinimumLaunchTCB.TeeSpl,
 			SnpSpl:   p.MinimumLaunchTCB.SnpSpl,
 			UcodeSpl: p.MinimumLaunchTCB.UcodeSpl,
-		}
-	case ProductTurin:
-		// Library TCB comparison uses the Genoa layout; leave zero and
-		// enforce via CheckTurinTCB instead.
-	default:
-		return nil, fmt.Errorf("unsupported SEV product line %q", productLine)
-	}
-
-	return opts, nil
-}
-
-// TurinTCB is the decomposition of a family-1Ah TCB_VERSION.
-type TurinTCB struct {
-	FmcSpl   uint8
-	BlSpl    uint8
-	TeeSpl   uint8
-	SnpSpl   uint8
-	UcodeSpl uint8
-}
-
-// DecomposeTurinTCB interprets a raw TCB_VERSION under the Turin layout:
-// FMC[7:0] BL[15:8] TEE[23:16] SNP[31:24] reserved[55:32] UCODE[63:56].
-func DecomposeTurinTCB(tcb uint64) TurinTCB {
-	return TurinTCB{
-		FmcSpl:   uint8(tcb),
-		BlSpl:    uint8(tcb >> 8),
-		TeeSpl:   uint8(tcb >> 16),
-		SnpSpl:   uint8(tcb >> 24),
-		UcodeSpl: uint8(tcb >> 56),
-	}
-}
-
-// CheckTurinTCB enforces the policy TCB floor against a raw Turin
-// TCB_VERSION value from a verified report.
-func (p *SEVSNPPolicy) CheckTurinTCB(field string, raw uint64, floor TCB) error {
-	got := DecomposeTurinTCB(raw)
-	var wantFmc uint8
-	if floor.FmcSpl != nil {
-		wantFmc = *floor.FmcSpl
-	}
-	if got.FmcSpl < wantFmc || got.BlSpl < floor.BlSpl || got.TeeSpl < floor.TeeSpl ||
-		got.SnpSpl < floor.SnpSpl || got.UcodeSpl < floor.UcodeSpl {
-		return fmt.Errorf("%s %+v is below policy floor %+v", field, got, floor)
-	}
-	return nil
+		},
+		VMPL: p.VMPL,
+	}, nil
 }
 
 // TDXOptions translates the policy block into go-tdx-guest validation

--- a/verifier/policy/translate.go
+++ b/verifier/policy/translate.go
@@ -1,0 +1,218 @@
+package policy
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+
+	sevabi "github.com/google/go-sev-guest/abi"
+	"github.com/google/go-sev-guest/kds"
+	sevvalidate "github.com/google/go-sev-guest/validate"
+	tdxvalidate "github.com/google/go-tdx-guest/validate"
+)
+
+// AMD product lines with distinct TCB_VERSION layouts.
+const (
+	ProductGenoa = "Genoa"
+	ProductTurin = "Turin"
+)
+
+// SEVOptions translates the policy block into go-sev-guest validation
+// options for the given product line.
+//
+// For Genoa (family 19h) the TCB floors map onto the library's TCBParts.
+// For Turin (family 1Ah) the TCB_VERSION layout differs (FMC[7:0] BL[15:8]
+// TEE[23:16] SNP[31:24] UCODE[63:56]) and go-sev-guest v0.14.x has no FMC
+// support, so the library TCB floors are left unset and callers MUST enforce
+// TCB via CheckTurinTCB on the verified report's reported and launch TCBs.
+func (p *SEVSNPPolicy) SEVOptions(productLine string) (*sevvalidate.Options, error) {
+	version, err := parseAPIVersion(p.MinimumAPIVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := &sevvalidate.Options{
+		GuestPolicy: sevabi.SnpPolicy{
+			Debug:        p.GuestPolicy.Debug,
+			SMT:          p.GuestPolicy.SMT,
+			MigrateMA:    p.GuestPolicy.MigrateMA,
+			SingleSocket: p.GuestPolicy.SingleSocket,
+		},
+		MinimumGuestSvn:           p.MinimumGuestSVN,
+		MinimumBuild:              p.MinimumBuild,
+		MinimumVersion:            version,
+		PermitProvisionalFirmware: p.PermitProvisionalFirmware,
+		PlatformInfo: &sevabi.SnpPlatformInfo{
+			SMTEnabled:                  p.PlatformInfo.SMTEnabled,
+			TSMEEnabled:                 p.PlatformInfo.TSMEEnabled,
+			ECCEnabled:                  p.PlatformInfo.ECCEnabled,
+			RAPLDisabled:                p.PlatformInfo.RAPLDisabled,
+			CiphertextHidingDRAMEnabled: p.PlatformInfo.CiphertextHidingDRAM,
+		},
+		VMPL: p.VMPL,
+	}
+
+	switch productLine {
+	case ProductGenoa:
+		if p.MinimumTCB.FmcSpl != nil || p.MinimumLaunchTCB.FmcSpl != nil {
+			return nil, fmt.Errorf("fmc_spl is not valid for product line %s", productLine)
+		}
+		opts.MinimumTCB = kds.TCBParts{
+			BlSpl:    p.MinimumTCB.BlSpl,
+			TeeSpl:   p.MinimumTCB.TeeSpl,
+			SnpSpl:   p.MinimumTCB.SnpSpl,
+			UcodeSpl: p.MinimumTCB.UcodeSpl,
+		}
+		opts.MinimumLaunchTCB = kds.TCBParts{
+			BlSpl:    p.MinimumLaunchTCB.BlSpl,
+			TeeSpl:   p.MinimumLaunchTCB.TeeSpl,
+			SnpSpl:   p.MinimumLaunchTCB.SnpSpl,
+			UcodeSpl: p.MinimumLaunchTCB.UcodeSpl,
+		}
+	case ProductTurin:
+		// Library TCB comparison uses the Genoa layout; leave zero and
+		// enforce via CheckTurinTCB instead.
+	default:
+		return nil, fmt.Errorf("unsupported SEV product line %q", productLine)
+	}
+
+	return opts, nil
+}
+
+// TurinTCB is the decomposition of a family-1Ah TCB_VERSION.
+type TurinTCB struct {
+	FmcSpl   uint8
+	BlSpl    uint8
+	TeeSpl   uint8
+	SnpSpl   uint8
+	UcodeSpl uint8
+}
+
+// DecomposeTurinTCB interprets a raw TCB_VERSION under the Turin layout:
+// FMC[7:0] BL[15:8] TEE[23:16] SNP[31:24] reserved[55:32] UCODE[63:56].
+func DecomposeTurinTCB(tcb uint64) TurinTCB {
+	return TurinTCB{
+		FmcSpl:   uint8(tcb),
+		BlSpl:    uint8(tcb >> 8),
+		TeeSpl:   uint8(tcb >> 16),
+		SnpSpl:   uint8(tcb >> 24),
+		UcodeSpl: uint8(tcb >> 56),
+	}
+}
+
+// CheckTurinTCB enforces the policy TCB floor against a raw Turin
+// TCB_VERSION value from a verified report.
+func (p *SEVSNPPolicy) CheckTurinTCB(field string, raw uint64, floor TCB) error {
+	got := DecomposeTurinTCB(raw)
+	var wantFmc uint8
+	if floor.FmcSpl != nil {
+		wantFmc = *floor.FmcSpl
+	}
+	if got.FmcSpl < wantFmc || got.BlSpl < floor.BlSpl || got.TeeSpl < floor.TeeSpl ||
+		got.SnpSpl < floor.SnpSpl || got.UcodeSpl < floor.UcodeSpl {
+		return fmt.Errorf("%s %+v is below policy floor %+v", field, got, floor)
+	}
+	return nil
+}
+
+// TDXOptions translates the policy block into go-tdx-guest validation
+// options. MR_SEAM membership, the TCB evaluation data number, and platform
+// measurement matching are not expressible in the library options and are
+// enforced by the companion methods below.
+func (p *TDXPolicy) TDXOptions() (*tdxvalidate.Options, error) {
+	qeVendor, err := hexField("qe_vendor_id", p.QEVendorID, 16)
+	if err != nil {
+		return nil, err
+	}
+	teeTcbSvn, err := hexField("minimum_tee_tcb_svn", p.MinimumTEETCBSVN, 16)
+	if err != nil {
+		return nil, err
+	}
+	tdAttributes, err := hexField("td_attributes", p.TDAttributes, 8)
+	if err != nil {
+		return nil, err
+	}
+	xfam, err := hexField("xfam", p.XFAM, 8)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := &tdxvalidate.Options{
+		HeaderOptions: tdxvalidate.HeaderOptions{
+			MinimumQeSvn:  p.MinimumQESVN,
+			MinimumPceSvn: p.MinimumPCESVN,
+			QeVendorID:    qeVendor,
+		},
+		TdQuoteBodyOptions: tdxvalidate.TdQuoteBodyOptions{
+			MinimumTeeTcbSvn: teeTcbSvn,
+			TdAttributes:     tdAttributes,
+			Xfam:             xfam,
+		},
+	}
+	if p.MRConfigIDZero {
+		opts.TdQuoteBodyOptions.MrConfigID = make([]byte, 48)
+	}
+	if p.MROwnerZero {
+		opts.TdQuoteBodyOptions.MrOwner = make([]byte, 48)
+	}
+	if p.MROwnerConfigZero {
+		opts.TdQuoteBodyOptions.MrOwnerConfig = make([]byte, 48)
+	}
+	return opts, nil
+}
+
+// CheckMRSeam verifies membership of the quote's MR_SEAM in the policy's
+// accepted set.
+func (p *TDXPolicy) CheckMRSeam(mrSeam []byte) error {
+	for _, accepted := range p.AcceptedMRSeams {
+		want, err := hex.DecodeString(accepted)
+		if err != nil {
+			return fmt.Errorf("policy accepted_mr_seams entry is not hex: %w", err)
+		}
+		if bytes.Equal(mrSeam, want) {
+			return nil
+		}
+	}
+	return fmt.Errorf("MR_SEAM %s is not in the policy's accepted set", hex.EncodeToString(mrSeam))
+}
+
+// CheckPlatformMeasurement verifies the quote's MRTD/RTMR0 against the
+// platform measurements the policy allows, resolved through the artifact.
+func (a *Artifact) CheckPlatformMeasurement(p *TDXPolicy, mrtdHex, rtmr0Hex string) error {
+	for _, ref := range p.PlatformMeasurements {
+		m := a.Measurements[ref]
+		if m.MRTD == mrtdHex && m.RTMR0 == rtmr0Hex {
+			return nil
+		}
+	}
+	return fmt.Errorf("platform measurements (mrtd %s...) do not match any allowed configuration", truncID(mrtdHex))
+}
+
+func parseAPIVersion(v string) (uint16, error) {
+	major, minor, found := strings.Cut(v, ".")
+	if !found {
+		return 0, fmt.Errorf("minimum_api_version %q is not maj.min", v)
+	}
+	maj, err := strconv.ParseUint(major, 10, 8)
+	if err != nil {
+		return 0, fmt.Errorf("minimum_api_version major: %w", err)
+	}
+	min, err := strconv.ParseUint(minor, 10, 8)
+	if err != nil {
+		return 0, fmt.Errorf("minimum_api_version minor: %w", err)
+	}
+	return uint16(maj<<8 | min), nil
+}
+
+func hexField(name, value string, wantLen int) ([]byte, error) {
+	b, err := hex.DecodeString(value)
+	if err != nil {
+		return nil, fmt.Errorf("%s is not hex: %w", name, err)
+	}
+	if len(b) != wantLen {
+		return nil, fmt.Errorf("%s must be %d bytes, got %d", name, wantLen, len(b))
+	}
+	return b, nil
+}

--- a/verifier/sigstore/endorsements_test.go
+++ b/verifier/sigstore/endorsements_test.go
@@ -1,0 +1,34 @@
+package sigstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tinfoilsh/tinfoil-go/verifier/github"
+)
+
+// TestLatestPlatformEndorsements is a live test against the published
+// artifact. It skips until the publisher's first release carrying the
+// tinfoil.hash + attestation is reachable through the proxy.
+func TestLatestPlatformEndorsements(t *testing.T) {
+	if _, err := github.FetchLatestDigest(platformEndorsementsRepo); err != nil {
+		// The proxy surfaces missing release assets as 4xx; skip until the
+		// first release carrying the endorsement assets is tagged.
+		t.Skipf("platform-endorsements digest not fetchable (asset not published yet?): %v", err)
+	}
+
+	client, err := NewClient()
+	require.NoError(t, err)
+
+	artifact, err := client.LatestPlatformEndorsements()
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, artifact.Machines)
+	assert.NotEmpty(t, artifact.Policies)
+	for identifier, policyName := range artifact.Machines {
+		_, _, err := artifact.PolicyFor(identifier, artifact.Policies[policyName].Platform)
+		assert.NoError(t, err)
+	}
+}

--- a/verifier/sigstore/sigstore.go
+++ b/verifier/sigstore/sigstore.go
@@ -10,13 +10,20 @@ import (
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/tuf"
 	"github.com/sigstore/sigstore-go/pkg/verify"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/tinfoilsh/tinfoil-go/verifier/attestation"
 	"github.com/tinfoilsh/tinfoil-go/verifier/github"
+	"github.com/tinfoilsh/tinfoil-go/verifier/policy"
 )
 
 const (
 	oidcIssuer = "https://token.actions.githubusercontent.com"
+
+	// platformEndorsementsRepo publishes the platform-endorsements artifact
+	// and is the only signing workflow identity accepted for it. Its digest
+	// is published under the standard tinfoil.hash release asset.
+	platformEndorsementsRepo = "tinfoilsh/platform-endorsements"
 )
 
 type Client struct {
@@ -282,6 +289,41 @@ func VerifyAttestation(
 	}
 	client := &Client{trustRoot: trustRoot}
 	return client.VerifyAttestation(bundleJSON, repo, hexDigest)
+}
+
+// VerifyPlatformEndorsements verifies a Sigstore bundle for the
+// platform-endorsements artifact against the publisher identity and returns
+// the parsed, validated artifact.
+func (c *Client) VerifyPlatformEndorsements(bundleJSON []byte, hexDigest string) (*policy.Artifact, error) {
+	result, err := c.VerifyBundle(bundleJSON, platformEndorsementsRepo, hexDigest)
+	if err != nil {
+		return nil, fmt.Errorf("verifying platform endorsements bundle: %w", err)
+	}
+
+	if result.Statement.PredicateType != policy.ArtifactFormat {
+		return nil, fmt.Errorf("unexpected predicate type: %s", result.Statement.PredicateType)
+	}
+
+	predicateJSON, err := protojson.Marshal(result.Statement.Predicate)
+	if err != nil {
+		return nil, fmt.Errorf("encoding platform endorsements predicate: %w", err)
+	}
+	return policy.ParseArtifact(predicateJSON)
+}
+
+// LatestPlatformEndorsements fetches and verifies the latest
+// platform-endorsements artifact (endorsed machine identities and their
+// appraisal policies) from GitHub+Sigstore.
+func (c *Client) LatestPlatformEndorsements() (*policy.Artifact, error) {
+	digest, err := github.FetchLatestDigest(platformEndorsementsRepo)
+	if err != nil {
+		return nil, fmt.Errorf("fetching platform endorsements digest: %w", err)
+	}
+	bundleJSON, err := github.FetchAttestationBundle(platformEndorsementsRepo, digest)
+	if err != nil {
+		return nil, fmt.Errorf("fetching platform endorsements bundle: %w", err)
+	}
+	return c.VerifyPlatformEndorsements(bundleJSON, digest)
 }
 
 // LatestHardwareMeasurements fetches the latest hardware measurements from GitHub+Sigstore


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Sigstore-verified platform endorsements and enforces named appraisal policies during attestation for AMD SEV‑SNP (Genoa) and Intel TDX. Extracts machine identity from evidence and fails closed if the machine isn't endorsed.

- **New Features**
  - Parse and validate the `platform-endorsements` v1 artifact with strict checks; map machine IDs to policies.
  - Sigstore client: fetch and verify latest endorsements from `tinfoilsh/platform-endorsements` using the `tinfoil.hash` digest, then parse into policies.
  - SEV‑SNP: derive product from CPUID; verify report signature (`verifySevSignature`); endorsements-aware path enforces policy (Genoa only) and extracts CHIP_ID identity.
  - TDX: translate policy into validation options, enforce MR_SEAM and platform measurements, and extract PPID identity from the PCK leaf.

- **Dependencies**
  - Bump `github.com/google/go-sev-guest` to v0.15.0.

<sup>Written for commit 46b7026dba5d03325665775d05fa7000546ec31c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-go/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

