### PR TITLE
bump Go to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tinfoilsh/tinfoil-go
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
Fixes the failing govulncheck check: [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) (Encrypted Client Hello privacy leak in `crypto/tls`) is present in Go 1.26.4 and fixed in 1.26.5.

- [x] `go build ./...`
- [x] `govulncheck ./...` — no vulnerabilities found

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump Go to 1.26.5 to fix `GO-2026-5856` (Encrypted Client Hello privacy leak in `crypto/tls`) and clear `govulncheck`.

Only `go.mod` is updated; `go build ./...` and `govulncheck ./...` pass.

<sup>Written for commit f522d3f2eb8e7c258b33f06885d088d75948914a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-go/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

