### PR TITLE
Harden Sigstore signing identity checks

### DIFF
--- a/verifier/sigstore/sigstore.go
+++ b/verifier/sigstore/sigstore.go
@@ -8,6 +8,7 @@ import (
 
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	"github.com/sigstore/sigstore-go/pkg/bundle"
+	"github.com/sigstore/sigstore-go/pkg/fulcio/certificate"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/tuf"
 	"github.com/sigstore/sigstore-go/pkg/verify"
@@ -127,11 +128,21 @@ func (c *Client) verifyBundleWithIdentity(bundleJSON []byte, sanRegex, hexDigest
 		return nil, fmt.Errorf("creating signed entity verifier: %w", err)
 	}
 
-	certID, err := verify.NewShortCertificateIdentity(
-		oidcIssuer,
-		"",
-		"",
-		sanRegex,
+	sanMatcher, err := verify.NewSANMatcher("", sanRegex)
+	if err != nil {
+		return nil, fmt.Errorf("creating SAN matcher: %w", err)
+	}
+	issuerMatcher, err := verify.NewIssuerMatcher(oidcIssuer, "")
+	if err != nil {
+		return nil, fmt.Errorf("creating issuer matcher: %w", err)
+	}
+	// runner_environment comes from the OIDC token, so a workflow retargeted
+	// to self-hosted (operator-controlled) infrastructure cannot claim
+	// github-hosted.
+	certID, err := verify.NewCertificateIdentity(
+		sanMatcher,
+		issuerMatcher,
+		certificate.Extensions{RunnerEnvironment: "github-hosted"},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating certificate identity: %w", err)

--- a/verifier/sigstore/sigstore.go
+++ b/verifier/sigstore/sigstore.go
@@ -3,6 +3,7 @@ package sigstore
 import (
 	"encoding/hex"
 	"fmt"
+	"regexp"
 	"strings"
 
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
@@ -74,9 +75,26 @@ func FetchTrustRoot() ([]byte, error) {
 	return client.GetTarget("trusted_root.json")
 }
 
+// repoNameRE matches a GitHub "owner/name" repository slug.
+var repoNameRE = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
+
+// signingIdentity returns the anchored SAN regex accepted for artifacts
+// signed from repo: one workflow file directly under the repository's
+// .github/workflows directory, run from a tag ref. The repository name is
+// validated and escaped so it cannot alter the pattern.
+func signingIdentity(repo string) (string, error) {
+	if !repoNameRE.MatchString(repo) {
+		return "", fmt.Errorf("invalid repository name %q", repo)
+	}
+	return "^https://github\\.com/" + regexp.QuoteMeta(repo) +
+		"/\\.github/workflows/[^/@]+@refs/tags/[^@]+$", nil
+}
+
 func (c *Client) VerifyBundle(bundleJSON []byte, repo, hexDigest string) (*verify.VerificationResult, error) {
-	// TODO: Can we pin this to latest without fetching the latest release?
-	sanRegex := "^https://github.com/" + repo + "/.github/workflows/.*@refs/tags/*"
+	sanRegex, err := signingIdentity(repo)
+	if err != nil {
+		return nil, err
+	}
 	return c.verifyBundleWithIdentity(bundleJSON, sanRegex, hexDigest)
 }
 

--- a/verifier/sigstore/sigstore_test.go
+++ b/verifier/sigstore/sigstore_test.go
@@ -1,12 +1,39 @@
 package sigstore
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tinfoilsh/tinfoil-go/verifier/attestation"
 	"github.com/tinfoilsh/tinfoil-go/verifier/github"
 )
+
+func TestSigningIdentity(t *testing.T) {
+	pattern, err := signingIdentity("tinfoilsh/confidential-model")
+	require.NoError(t, err)
+	re := regexp.MustCompile(pattern)
+
+	assert.True(t, re.MatchString(
+		"https://github.com/tinfoilsh/confidential-model/.github/workflows/release.yml@refs/tags/v1.2.3"))
+
+	for name, san := range map[string]string{
+		"other repo prefix":     "https://github.com/tinfoilsh/confidential-modelx/.github/workflows/release.yml@refs/tags/v1",
+		"unescaped dot in host": "https://githubXcom/tinfoilsh/confidential-model/.github/workflows/release.yml@refs/tags/v1",
+		"branch ref":            "https://github.com/tinfoilsh/confidential-model/.github/workflows/release.yml@refs/heads/main",
+		"nested workflow path":  "https://github.com/tinfoilsh/confidential-model/.github/workflows/a/b.yml@refs/tags/v1",
+		"trailing content":      "https://github.com/tinfoilsh/confidential-model/.github/workflows/release.yml@refs/tags/v1@evil",
+		"embedded match":        "prefix https://github.com/tinfoilsh/confidential-model/.github/workflows/release.yml@refs/tags/v1",
+	} {
+		assert.False(t, re.MatchString(san), name)
+	}
+
+	for _, repo := range []string{"", "noslash", "a/b/c", "a/(b|c)"} {
+		_, err := signingIdentity(repo)
+		assert.Error(t, err, repo)
+	}
+}
 
 func TestFetchHardwarePlatformMeasurements(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
## Summary
- Validate, escape, and anchor the code-repo SAN regex: exactly one workflow file directly under `.github/workflows/`, tag refs only, no trailing SAN content. The repository slug is validated so it cannot alter the pattern.
- Require the Fulcio `runner_environment` extension to equal `github-hosted`, rejecting artifacts signed from self-hosted runners even under a matching workflow identity.

## Test plan
- [x] `TestSigningIdentity` covers prefix-repo, unescaped-dot host, branch refs, nested workflow paths, trailing content, and embedded-match bypasses
- [x] Live `TestVerifyAttestation` and `TestLatestPlatformEndorsements` pass against production bundles
- [x] `go test -short ./verifier/...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens Sigstore verification by pinning the workflow SAN to a specific repo workflow and requiring GitHub-hosted runners. This prevents repo/host spoofing and rejects self-hosted runner signatures.

- **Bug Fixes**
  - Hardened SAN regex: anchored and escaped to accept only `https://github.com/<owner>/<repo>/.github/workflows/<file>@refs/tags/<tag>`.
  - Validates and escapes the repo slug to block regex injection, prefix/embedded matches, nested workflow paths, branch refs, and trailing content.
  - Enforces Fulcio `runner_environment=github-hosted` via certificate identity checks; self-hosted runner signatures are rejected.

- **Migration**
  - Release signing must run on GitHub-hosted runners.

<sup>Written for commit 12effef33240027dce4a4730ec5da6834a78d9f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-go/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

