### PR TITLE
fix: align proxy transport requirements

### DIFF
--- a/ehbp_transport.go
+++ b/ehbp_transport.go
@@ -2,8 +2,10 @@ package tinfoil
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/openai/openai-go/v3/option"
@@ -42,6 +44,7 @@ type clientConfig struct {
 	repo                 string
 	transport            TransportMode
 	baseURL              string
+	baseURLSet           bool
 	attestationBundleURL string
 	userCacheSecret      string
 	userCacheSecretSet   bool
@@ -72,9 +75,13 @@ func WithTransport(mode TransportMode) ClientOption {
 // encrypted end-to-end to the verified enclave; when the base URL's origin
 // differs from the enclave's, the SDK adds the X-Tinfoil-Enclave-Url header so
 // the proxy can forward the encrypted request to the right enclave. Only
-// supported with the EHBP transport.
+// supported with the EHBP transport unless it uses the verified enclave's
+// HTTPS origin.
 func WithBaseURL(baseURL string) ClientOption {
-	return func(c *clientConfig) { c.baseURL = baseURL }
+	return func(c *clientConfig) {
+		c.baseURL = baseURL
+		c.baseURLSet = true
+	}
 }
 
 // WithAttestationBundleURL fetches the attestation bundle from the given base
@@ -109,10 +116,10 @@ func NewClientWithOptions(opts ...ClientOption) (*Client, error) {
 	if cfg.repo == "" {
 		cfg.repo = defaultConfigRepo
 	}
-	// Routing through a proxy base URL relies on EHBP sealing the body to the
-	// enclave; TLS certificate pinning would reject the proxy's certificate.
-	if cfg.baseURL != "" && cfg.transport == TransportTLS {
-		return nil, fmt.Errorf("WithBaseURL is only supported with the EHBP transport")
+	if cfg.baseURLSet {
+		if _, err := originOf(cfg.baseURL); err != nil {
+			return nil, fmt.Errorf("invalid base URL: %w", err)
+		}
 	}
 
 	var secureClient *client.SecureClient
@@ -139,9 +146,9 @@ func NewClientWithOptions(opts ...ClientOption) (*Client, error) {
 // secureHTTPClient builds an *http.Client for the requested transport mode.
 //
 // The returned client is bound to the verified enclave (and the configured
-// proxy, if any): neither EHBP nor TLS pinning encrypts request headers, which
-// may carry the API key, so requests to any other host or over plain http are
-// refused.
+// proxy, if any). EHBP does not encrypt request headers end-to-end; TLS encrypts
+// them in transit, but sending them to another origin would disclose them to
+// that endpoint. Requests to any other origin are therefore refused.
 func secureHTTPClient(secureClient *client.SecureClient, mode TransportMode, baseURL, userCacheSecret string) (*http.Client, error) {
 	var (
 		httpClient *http.Client
@@ -157,6 +164,11 @@ func secureHTTPClient(secureClient *client.SecureClient, mode TransportMode, bas
 	}
 	if err != nil {
 		return nil, err
+	}
+	if mode == TransportTLS {
+		if err := validateTLSBaseURL(baseURL, secureClient.Enclave()); err != nil {
+			return nil, err
+		}
 	}
 
 	// The cache-secret layer sits above the sealing transport, so the field it
@@ -204,9 +216,9 @@ func allowedOrigins(enclave, baseURL string) (map[string]struct{}, error) {
 }
 
 // hostBoundRoundTripper rejects requests to any origin other than the verified
-// enclave or the configured proxy, and refuses non-https requests. This guards
-// the escape-hatch HTTP client (and the OpenAI client) from leaking plaintext
-// request headers, such as the API key, to an arbitrary host.
+// enclave or the configured proxy. This guards the escape-hatch HTTP client
+// (and the OpenAI client) from disclosing sensitive request headers, such as the
+// API key, to an arbitrary host.
 type hostBoundRoundTripper struct {
 	allowedOrigins map[string]struct{}
 	enclave        string
@@ -214,10 +226,7 @@ type hostBoundRoundTripper struct {
 }
 
 func (t *hostBoundRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	if req.URL.Scheme != "https" {
-		return nil, fmt.Errorf("refusing to send request over non-https URL %q", req.URL.String())
-	}
-	origin := req.URL.Scheme + "://" + req.URL.Host
+	origin := normalizedOrigin(req.URL)
 	if _, ok := t.allowedOrigins[origin]; !ok {
 		return nil, fmt.Errorf("refusing to send request to %q: client is bound to enclave %q", origin, t.enclave)
 	}
@@ -312,10 +321,52 @@ func originOf(rawURL string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if u.Host == "" {
-		return "", fmt.Errorf("missing host in URL %q", rawURL)
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("URL must be absolute: %q", rawURL)
 	}
-	return u.Scheme + "://" + u.Host, nil
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "https" && scheme != "http" {
+		return "", fmt.Errorf("URL must use http or https: %q", rawURL)
+	}
+	return normalizedOrigin(u), nil
+}
+
+// normalizedOrigin lowercases the scheme and host and drops an explicit
+// default port so that origins compare equal regardless of how the URL spells
+// them (for example https://host and https://host:443).
+func normalizedOrigin(u *url.URL) string {
+	scheme := strings.ToLower(u.Scheme)
+	hostname := strings.ToLower(u.Hostname())
+	port := u.Port()
+	if (scheme == "https" && port == "443") || (scheme == "http" && port == "80") {
+		port = ""
+	}
+	if port != "" {
+		return scheme + "://" + net.JoinHostPort(hostname, port)
+	}
+	if strings.Contains(hostname, ":") {
+		hostname = "[" + hostname + "]"
+	}
+	return scheme + "://" + hostname
+}
+
+func validateTLSBaseURL(baseURL, enclave string) error {
+	if baseURL == "" {
+		return nil
+	}
+
+	baseOrigin, err := originOf(baseURL)
+	if err != nil {
+		return fmt.Errorf("invalid base URL: %w", err)
+	}
+	enclaveOrigin, err := originOf("https://" + enclave)
+	if err != nil {
+		return err
+	}
+	if baseOrigin != enclaveOrigin {
+		return fmt.Errorf("TLS base URL must use the verified enclave origin %q", enclaveOrigin)
+	}
+	return nil
 }
 
 // enclaveURLHeaderTransport injects the X-Tinfoil-Enclave-Url header before

--- a/ehbp_transport_test.go
+++ b/ehbp_transport_test.go
@@ -64,16 +64,52 @@ func TestProxyClientOptionsApply(t *testing.T) {
 	WithAttestationBundleURL("https://proxy.example.com")(cfg)
 
 	require.Equal(t, "https://proxy.example.com/", cfg.baseURL)
+	require.True(t, cfg.baseURLSet)
 	require.Equal(t, "https://proxy.example.com", cfg.attestationBundleURL)
 }
 
-func TestNewClientWithOptionsRejectsBaseURLInTLSMode(t *testing.T) {
-	_, err := NewClientWithOptions(
-		WithBaseURL("https://proxy.example.com/"),
-		WithTransport(TransportTLS),
-	)
+func TestNewClientWithOptionsRejectsInvalidBaseURL(t *testing.T) {
+	for _, baseURL := range []string{"", "proxy.example.com", "ftp://proxy.example.com", "://"} {
+		t.Run(baseURL, func(t *testing.T) {
+			_, err := NewClientWithOptions(WithBaseURL(baseURL))
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid base URL")
+		})
+	}
+}
+
+func TestValidateTLSBaseURL(t *testing.T) {
+	require.NoError(t, validateTLSBaseURL("", "enclave.example.com"))
+	require.NoError(t, validateTLSBaseURL("https://enclave.example.com/custom/v1", "enclave.example.com"))
+	require.NoError(t, validateTLSBaseURL("https://enclave.example.com:443/custom/v1", "enclave.example.com"))
+
+	err := validateTLSBaseURL("https://proxy.example.com/v1", "enclave.example.com")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "EHBP")
+	require.Contains(t, err.Error(), "verified enclave origin")
+
+	err = validateTLSBaseURL("http://enclave.example.com/v1", "enclave.example.com")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "verified enclave origin")
+}
+
+func TestOriginOfNormalizesDefaultPorts(t *testing.T) {
+	tests := []struct {
+		rawURL string
+		want   string
+	}{
+		{"https://enclave.example.com:443/v1", "https://enclave.example.com"},
+		{"http://proxy.example.com:80/v1", "http://proxy.example.com"},
+		{"https://enclave.example.com:8443/v1", "https://enclave.example.com:8443"},
+		{"http://[::1]:80/v1", "http://[::1]"},
+		{"http://[::1]:8080/v1", "http://[::1]:8080"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.rawURL, func(t *testing.T) {
+			origin, err := originOf(tt.rawURL)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, origin)
+		})
+	}
 }
 
 func TestEnclaveURLHeaderValue(t *testing.T) {
@@ -87,6 +123,7 @@ func TestEnclaveURLHeaderValue(t *testing.T) {
 		{"proxy different origin", "https://proxy.example.com/", "enclave.example.com", "https://enclave.example.com", true},
 		{"proxy keeps path but different origin", "https://proxy.example.com/api/v1/", "enclave.example.com", "https://enclave.example.com", true},
 		{"base url is the enclave itself", "https://enclave.example.com/v1/", "enclave.example.com", "", false},
+		{"base url uses explicit default port", "https://enclave.example.com:443/v1/", "enclave.example.com", "", false},
 		{"no base url", "", "enclave.example.com", "", false},
 		{"no enclave", "https://proxy.example.com/", "", "", false},
 	}
@@ -161,7 +198,7 @@ func TestEHBPReVerifyingTransportRefreshesEnclaveHeaderOnRotation(t *testing.T) 
 }
 
 func TestHostBoundRoundTripperAllowsEnclaveAndProxy(t *testing.T) {
-	origins, err := allowedOrigins("enclave.example.com", "https://proxy.example.com/v1/")
+	origins, err := allowedOrigins("enclave.example.com", "http://proxy.example.com/v1/")
 	require.NoError(t, err)
 
 	var calls int
@@ -173,7 +210,9 @@ func TestHostBoundRoundTripperAllowsEnclaveAndProxy(t *testing.T) {
 
 	for _, target := range []string{
 		"https://enclave.example.com/v1/models",
-		"https://proxy.example.com/v1/chat/completions",
+		"https://enclave.example.com:443/v1/models",
+		"http://proxy.example.com/v1/chat/completions",
+		"http://proxy.example.com:80/v1/chat/completions",
 	} {
 		req, err := http.NewRequest(http.MethodGet, target, nil)
 		require.NoError(t, err)
@@ -181,7 +220,7 @@ func TestHostBoundRoundTripperAllowsEnclaveAndProxy(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 	}
-	require.Equal(t, 2, calls)
+	require.Equal(t, 4, calls)
 }
 
 func TestHostBoundRoundTripperRejectsForeignHostAndScheme(t *testing.T) {
@@ -203,7 +242,13 @@ func TestHostBoundRoundTripperRejectsForeignHostAndScheme(t *testing.T) {
 	require.NoError(t, err)
 	_, err = rt.RoundTrip(plaintext)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "non-https")
+	require.Contains(t, err.Error(), "http://enclave.example.com")
+
+	unsupported, err := http.NewRequest(http.MethodGet, "ftp://enclave.example.com/v1/models", nil)
+	require.NoError(t, err)
+	_, err = rt.RoundTrip(unsupported)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ftp://enclave.example.com")
 }
 
 func TestBuildEHBPTransportRequiresKey(t *testing.T) {

--- a/tinfoil_client.go
+++ b/tinfoil_client.go
@@ -141,9 +141,8 @@ func (c *Client) Verify() (*client.GroundTruth, error) {
 // HTTPClient returns the underlying HTTP client used to reach the enclave. It
 // re-verifies attestation automatically when the enclave rotates its key, and
 // it is bound to the verified enclave (and the configured proxy, if any):
-// requests to any other host, or over plain http, are refused because request
-// headers are not encrypted. This can be used for secure, direct HTTP requests
-// to the enclave.
+// requests to any other origin are refused to avoid disclosing sensitive
+// headers. This can be used for secure, direct HTTP requests to the enclave.
 func (c *Client) HTTPClient() *http.Client {
 	return c.httpClient
 }

--- a/verifier/client/client.go
+++ b/verifier/client/client.go
@@ -360,8 +360,8 @@ func (s *SecureClient) makeRequest(req *http.Request) (*Response, error) {
 		req.URL.Host = s.enclave
 	}
 
-	// Request headers (which may carry the API key) are not encrypted, so never
-	// send them over a plaintext connection.
+	// Request headers may carry the API key, so never send them over a plaintext
+	// connection.
 	if req.URL.Scheme != "https" {
 		return nil, fmt.Errorf("refusing to send request over non-https URL %q", req.URL.String())
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Align base URL and proxy rules across EHBP and TLS to prevent misconfig and leaks. We now validate base URLs on option set, allow HTTP proxies with EHBP, require the enclave’s HTTPS origin for TLS, and normalize origins for consistent checks and errors.

- **Bug Fixes**
  - `WithBaseURL`: require absolute http(s) URL when set; track `baseURLSet`; consistent "invalid base URL" errors.
  - TLS: `validateTLSBaseURL` allows empty base URL or requires origin to match `https://<enclave>`; accepts explicit default ports.
  - Request guard: `hostBoundRoundTripper` compares normalized origins, is case-insensitive, allows HTTP proxies, includes target origin (scheme/port) in errors, and rejects unsupported schemes/foreign hosts.
  - URL handling: `originOf` allows only absolute http(s), lowercases scheme/host, strips default ports, brackets IPv6; new `normalizedOrigin` used in checks.
  - Tests updated for invalid/empty base URLs, TLS origin enforcement, default port normalization, IPv6, HTTP proxy allowance, and clearer errors.

<sup>Written for commit 9218a86b3475ae41b95ee108c61305079d07a772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-go/pull/92?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

