### PR TITLE
fix: align prompt cache scoping with specification

### DIFF
--- a/ehbp_transport_test.go
+++ b/ehbp_transport_test.go
@@ -441,7 +441,9 @@ func TestResetRequestBodyNoBody(t *testing.T) {
 
 // TestClientIntegration_TransportModes exercises NewClientWithOptions against a
 // live enclave for both transport modes.
-func TestClientIntegration_TransportModes(t *testing.T) {
+func TestClientIntegration_TransportModesWithCacheSecret(t *testing.T) {
+	const testUserCacheSecret = "go-live-integration-cache-secret"
+
 	apiKey := os.Getenv("TINFOIL_API_KEY")
 	if apiKey == "" {
 		t.Skip("TINFOIL_API_KEY not set; skipping integration test")
@@ -451,6 +453,7 @@ func TestClientIntegration_TransportModes(t *testing.T) {
 		t.Run(string(mode), func(t *testing.T) {
 			c, err := NewClientWithOptions(
 				WithTransport(mode),
+				WithUserCacheSecret(testUserCacheSecret),
 				WithOpenAIOptions(option.WithAPIKey(apiKey)),
 			)
 			require.NoError(t, err)

--- a/user_cache_secret.go
+++ b/user_cache_secret.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -57,13 +58,14 @@ const (
 )
 
 // userCacheSecretPaths are the OpenAI-compatible endpoints whose bodies carry
-// the field. Matched by suffix so a proxy base URL with a path prefix still
-// qualifies. Other endpoints (embeddings, audio, files) are excluded: their
-// engines do not prefix-cache and may reject unknown fields.
+// the field. Matched by suffix with no /v1 prefix required, so custom base
+// URLs (path-prefixed proxies or /v1-less roots) still qualify. Other
+// endpoints (embeddings, audio, files) are excluded: their engines do not
+// prefix-cache and may reject unknown fields.
 var userCacheSecretPaths = []string{
-	"/v1/chat/completions",
-	"/v1/completions",
-	"/v1/responses",
+	"/chat/completions",
+	"/completions",
+	"/responses",
 }
 
 // WithUserCacheSecret sets the user cache secret explicitly, taking precedence
@@ -133,46 +135,121 @@ func loadOrGenerateUserCacheSecret() string {
 	dir := filepath.Join(home, userCacheSecretDirName)
 	path := filepath.Join(dir, userCacheSecretFileName)
 
-	if b, err := os.ReadFile(path); err == nil {
-		if s := strings.TrimSpace(string(b)); s != "" {
-			return s
+	if err := ensureUserCacheSecretDir(dir); err != nil {
+		return ephemeralUserCacheSecret()
+	}
+	persisted, err := readUserCacheSecret(path)
+	if err == nil {
+		if persisted != "" {
+			return persisted
 		}
+		return ephemeralUserCacheSecret()
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return ephemeralUserCacheSecret()
 	}
 
 	secret := newUserCacheSecret()
 	if secret == "" {
 		return ""
 	}
-	if err := os.MkdirAll(dir, 0o700); err != nil {
+	candidate, err := writeUserCacheSecretCandidate(dir, secret)
+	if err != nil {
 		return ephemeralUserCacheSecret()
 	}
+	defer os.Remove(candidate)
 
-	// O_EXCL so a concurrent first run loses the race cleanly: the loser
-	// re-reads and adopts the winner's secret instead of splitting the
-	// machine's namespace between two values.
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
-	switch {
-	case err == nil:
-		_, werr := f.WriteString(secret)
-		cerr := f.Close()
-		if werr == nil && cerr == nil {
-			return secret
-		}
-	case errors.Is(err, fs.ErrExist):
-		if b, rerr := os.ReadFile(path); rerr == nil {
-			if s := strings.TrimSpace(string(b)); s != "" {
-				return s
-			}
-		}
-	default:
+	if err := os.Link(candidate, path); err == nil {
+		return secret
+	} else if !errors.Is(err, fs.ErrExist) {
 		return ephemeralUserCacheSecret()
 	}
+	persisted, err = readUserCacheSecret(path)
+	if err != nil || persisted == "" {
+		return ephemeralUserCacheSecret()
+	}
+	return persisted
+}
 
-	// The file exists but is blank or torn: rewrite it in place.
-	if err := os.WriteFile(path, []byte(secret), 0o600); err != nil {
-		return ephemeralUserCacheSecret()
+func readUserCacheSecret(path string) (string, error) {
+	b, err := readUserCacheSecretFile(path)
+	if err != nil {
+		return "", err
 	}
-	return secret
+	if !utf8.Valid(b) {
+		return "", errors.New("user cache secret is not valid UTF-8")
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+func validateUserCacheSecretDir(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return errors.New("user cache secret directory is not a directory")
+	}
+	return nil
+}
+
+func ensureUserCacheSecretDir(path string) error {
+	err := validateUserCacheSecretDir(path)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		return err
+	}
+	return validateUserCacheSecretDir(path)
+}
+
+func readUserCacheSecretFile(path string) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.New("user cache secret path is not a regular file")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	info, err = f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.New("user cache secret path is not a regular file")
+	}
+	return io.ReadAll(f)
+}
+
+func writeUserCacheSecretCandidate(dir, secret string) (string, error) {
+	f, err := os.CreateTemp(dir, userCacheSecretFileName+".tmp-*")
+	if err != nil {
+		return "", err
+	}
+	path := f.Name()
+	ok := false
+	defer func() {
+		if !ok {
+			_ = os.Remove(path)
+		}
+	}()
+	if _, err := f.WriteString(secret); err != nil {
+		_ = f.Close()
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+	ok = true
+	return path, nil
 }
 
 // userCacheSecretTransport injects the client-level secret into request bodies
@@ -187,7 +264,7 @@ type userCacheSecretTransport struct {
 }
 
 func (t *userCacheSecretTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if t.secret == "" || !userCacheSecretPathEligible(req) {
+	if t.secret == "" || !userCacheSecretPathEligible(req) || req.GetBody == nil {
 		return t.transport.RoundTrip(req)
 	}
 
@@ -237,6 +314,9 @@ func userCacheSecretPathEligible(req *http.Request) bool {
 // bytes — for non-object bodies, trailing data, or a body that already carries
 // the field.
 func injectUserCacheSecret(raw []byte, secret string) ([]byte, bool) {
+	if !utf8.Valid(raw) {
+		return nil, false
+	}
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.UseNumber()
 	var body map[string]any

--- a/user_cache_secret_file_test.go
+++ b/user_cache_secret_file_test.go
@@ -1,0 +1,63 @@
+package tinfoil
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadUserCacheSecretFileRejectsStaticSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	link := filepath.Join(dir, "link")
+	contents := []byte("target-secret")
+	require.NoError(t, os.WriteFile(target, contents, 0o644))
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+
+	_, err := readUserCacheSecretFile(link)
+	require.Error(t, err)
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, contents, got)
+	requireFileMode(t, target, 0o644)
+}
+
+func TestValidateUserCacheSecretDirRejectsStaticSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	link := filepath.Join(dir, "link")
+	require.NoError(t, os.Mkdir(target, 0o755))
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+
+	require.Error(t, validateUserCacheSecretDir(link))
+	requireFileMode(t, target, 0o755)
+}
+
+func TestUserCacheSecretPathsRejectUnexpectedTypes(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "file")
+	directory := filepath.Join(dir, "directory")
+	require.NoError(t, os.WriteFile(file, []byte("unchanged"), 0o644))
+	require.NoError(t, os.Mkdir(directory, 0o755))
+
+	require.Error(t, validateUserCacheSecretDir(file))
+	_, err := readUserCacheSecretFile(directory)
+	require.Error(t, err)
+	requireFileMode(t, file, 0o644)
+	requireFileMode(t, directory, 0o755)
+}
+
+func TestUserCacheSecretPathsPreserveNotExist(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing")
+
+	require.ErrorIs(t, validateUserCacheSecretDir(missing), fs.ErrNotExist)
+	_, err := readUserCacheSecretFile(missing)
+	require.ErrorIs(t, err, fs.ErrNotExist)
+}

--- a/user_cache_secret_test.go
+++ b/user_cache_secret_test.go
@@ -1,13 +1,18 @@
 package tinfoil
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -97,7 +102,46 @@ func TestUserCacheSecretAdoptsExistingFile(t *testing.T) {
 	require.Equal(t, "shared-secret", resolveUserCacheSecret("", false))
 }
 
-func TestUserCacheSecretRewritesBlankFile(t *testing.T) {
+func TestUserCacheSecretRejectsInvalidUTF8WithoutRewriting(t *testing.T) {
+	unsetUserCacheSecretEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(home, userCacheSecretDirName)
+	path := filepath.Join(dir, userCacheSecretFileName)
+	corrupted := []byte{0xff, 0xfe, 'a'}
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	require.NoError(t, os.WriteFile(path, corrupted, 0o600))
+
+	first := resolveUserCacheSecret("", false)
+	require.Len(t, first, 64)
+	require.Equal(t, first, resolveUserCacheSecret("", false))
+	persisted, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, corrupted, persisted)
+}
+
+func TestUserCacheSecretAcceptsPermissiveExistingPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose POSIX permission bits")
+	}
+	unsetUserCacheSecretEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(home, userCacheSecretDirName)
+	path := filepath.Join(dir, userCacheSecretFileName)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	require.NoError(t, os.WriteFile(path, []byte("shared-secret"), 0o600))
+	require.NoError(t, os.Chmod(dir, 0o777))
+	require.NoError(t, os.Chmod(path, 0o666))
+
+	require.Equal(t, "shared-secret", resolveUserCacheSecret("", false))
+	requireFileMode(t, dir, 0o777)
+	requireFileMode(t, path, 0o666)
+}
+
+func TestUserCacheSecretLeavesBlankFileUntouched(t *testing.T) {
 	unsetUserCacheSecretEnv(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -107,12 +151,118 @@ func TestUserCacheSecretRewritesBlankFile(t *testing.T) {
 	require.NoError(t, os.MkdirAll(dir, 0o700))
 	require.NoError(t, os.WriteFile(path, []byte("  \n"), 0o600))
 
-	secret := resolveUserCacheSecret("", false)
-	require.Len(t, secret, 64)
-
+	first := resolveUserCacheSecret("", false)
+	require.Len(t, first, 64)
+	require.Equal(t, first, resolveUserCacheSecret("", false))
 	written, err := os.ReadFile(path)
 	require.NoError(t, err)
-	require.Equal(t, secret, strings.TrimSpace(string(written)), "a blank file must be replaced with the generated secret")
+	require.Equal(t, []byte("  \n"), written)
+}
+
+func TestUserCacheSecretConcurrentProcesses(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, userCacheSecretDirName, userCacheSecretFileName)
+	secrets := runUserCacheSecretContenders(t, home, userCacheSecretContenderCount)
+	for _, secret := range secrets {
+		require.Equal(t, secrets[0], secret, "all processes must adopt the elected value")
+		require.Len(t, secret, 64)
+	}
+	persisted, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, secrets[0], strings.TrimSpace(string(persisted)))
+	requireFileMode(t, path, 0o600)
+}
+
+func TestUserCacheSecretSubprocess(t *testing.T) {
+	if os.Getenv("TINFOIL_CACHE_SECRET_HELPER") != "1" {
+		return
+	}
+	_ = os.Unsetenv(userCacheSecretEnv)
+	fmt.Println("ready")
+	var release [1]byte
+	if _, err := io.ReadFull(os.Stdin, release[:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	fmt.Println(resolveUserCacheSecret("", false))
+	os.Exit(0)
+}
+
+const userCacheSecretContenderCount = 8
+
+type userCacheSecretContender struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout *bufio.Reader
+	stderr bytes.Buffer
+}
+
+func runUserCacheSecretContenders(t *testing.T, home string, count int) []string {
+	t.Helper()
+	contenders := make([]userCacheSecretContender, count)
+	for i := range contenders {
+		cmd := exec.Command(os.Args[0], "-test.run=^TestUserCacheSecretSubprocess$")
+		cmd.Env = userCacheSecretHelperEnv(home)
+		stdin, err := cmd.StdinPipe()
+		require.NoError(t, err)
+		stdout, err := cmd.StdoutPipe()
+		require.NoError(t, err)
+		contenders[i] = userCacheSecretContender{
+			cmd:    cmd,
+			stdin:  stdin,
+			stdout: bufio.NewReader(stdout),
+		}
+		cmd.Stderr = &contenders[i].stderr
+		require.NoError(t, cmd.Start())
+		ready, err := contenders[i].stdout.ReadString('\n')
+		require.NoError(t, err)
+		require.Equal(t, "ready", strings.TrimSpace(ready))
+	}
+
+	for i := range contenders {
+		_, err := contenders[i].stdin.Write([]byte{1})
+		require.NoError(t, err)
+		require.NoError(t, contenders[i].stdin.Close())
+	}
+
+	secrets := make([]string, count)
+	for i := range contenders {
+		secret, err := contenders[i].stdout.ReadString('\n')
+		require.NoError(t, err)
+		waitErr := contenders[i].cmd.Wait()
+		require.NoError(t, waitErr, contenders[i].stderr.String())
+		secrets[i] = strings.TrimSpace(secret)
+	}
+	return secrets
+}
+
+func userCacheSecretHelperEnv(home string) []string {
+	env := make([]string, 0, len(os.Environ())+3)
+	for _, value := range os.Environ() {
+		if strings.HasPrefix(value, "HOME=") ||
+			strings.HasPrefix(value, "USERPROFILE=") ||
+			strings.HasPrefix(value, userCacheSecretEnv+"=") ||
+			strings.HasPrefix(value, "TINFOIL_CACHE_SECRET_HELPER=") {
+			continue
+		}
+		env = append(env, value)
+	}
+	return append(
+		env,
+		"HOME="+home,
+		"USERPROFILE="+home,
+		"TINFOIL_CACHE_SECRET_HELPER=1",
+	)
+}
+
+func requireFileMode(t *testing.T, path string, mode os.FileMode) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return
+	}
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, mode, info.Mode().Perm())
 }
 
 func TestUserCacheSecretFallsBackWithoutHome(t *testing.T) {
@@ -168,6 +318,7 @@ func TestUserCacheSecretTransportInjects(t *testing.T) {
 		"/v1/completions",
 		"/v1/responses",
 		"/api/v1/chat/completions", // proxy base URL with a path prefix
+		"/chat/completions",        // custom base URL without a /v1 root
 	}
 	for _, path := range paths {
 		t.Run(path, func(t *testing.T) {
@@ -201,12 +352,14 @@ func TestUserCacheSecretTransportInjects(t *testing.T) {
 
 func TestUserCacheSecretTransportSkipsIneligibleRequests(t *testing.T) {
 	t.Run("non-allowlisted endpoint forwards the body untouched", func(t *testing.T) {
-		var got []byte
-		transport := captureTransport("s1", &got, nil)
-		const raw = `{"model":"m","input":"text"}`
-		_, err := transport.RoundTrip(postJSONRequest(t, "https://enclave.example.com/v1/embeddings", raw))
-		require.NoError(t, err)
-		require.Equal(t, raw, string(got))
+		for _, path := range []string{"/v1/embeddings", "/embeddings"} {
+			var got []byte
+			transport := captureTransport("s1", &got, nil)
+			const raw = `{"model":"m","input":"text"}`
+			_, err := transport.RoundTrip(postJSONRequest(t, "https://enclave.example.com"+path, raw))
+			require.NoError(t, err)
+			require.Equal(t, raw, string(got))
+		}
 	})
 
 	t.Run("GET with no body is forwarded as-is", func(t *testing.T) {
@@ -226,6 +379,23 @@ func TestUserCacheSecretTransportSkipsIneligibleRequests(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, raw, string(got))
 	})
+}
+
+func TestUserCacheSecretTransportLeavesStreamingBodyUntouched(t *testing.T) {
+	const raw = `{"model":"m"}`
+	var got []byte
+	transport := captureTransport("s1", &got, nil)
+	req, err := http.NewRequest(
+		http.MethodPost,
+		"https://enclave.example.com/v1/chat/completions",
+		io.NopCloser(strings.NewReader(raw)),
+	)
+	require.NoError(t, err)
+	require.Nil(t, req.GetBody)
+
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, raw, string(got))
 }
 
 func TestUserCacheSecretTransportNeverClobbers(t *testing.T) {
@@ -268,6 +438,21 @@ func TestUserCacheSecretTransportNonObjectBodies(t *testing.T) {
 			require.Equal(t, raw, string(got), "bodies the router-side schema would reject must be forwarded untouched")
 		})
 	}
+}
+
+func TestUserCacheSecretTransportInvalidUTF8(t *testing.T) {
+	raw := []byte{'{', '"', 'x', '"', ':', '"', 0xff, '"', '}'}
+	var got []byte
+	transport := captureTransport("s1", &got, nil)
+	req, err := http.NewRequest(
+		http.MethodPost,
+		"https://enclave.example.com/v1/chat/completions",
+		bytes.NewReader(raw),
+	)
+	require.NoError(t, err)
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, raw, got, "invalid UTF-8 JSON must be forwarded byte-for-byte")
 }
 
 func TestUserCacheSecretTransportAllowsTrailingWhitespace(t *testing.T) {

--- a/user_cache_secret_unix_test.go
+++ b/user_cache_secret_unix_test.go
@@ -1,0 +1,65 @@
+package tinfoil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserCacheSecretRejectsSymlinksWithoutTouchingTargets(t *testing.T) {
+	unsetUserCacheSecretEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, userCacheSecretDirName)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+
+	target := filepath.Join(home, "symlink-target")
+	targetContents := []byte("target-secret")
+	require.NoError(t, os.WriteFile(target, targetContents, 0o644))
+	if err := os.Symlink(target, filepath.Join(dir, userCacheSecretFileName)); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+
+	require.NotEqual(t, string(targetContents), resolveUserCacheSecret("", false))
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, targetContents, got)
+	requireFileMode(t, target, 0o644)
+}
+
+func TestUserCacheSecretRejectsSymlinkDirectoryWithoutTouchingTarget(t *testing.T) {
+	unsetUserCacheSecretEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	target := filepath.Join(home, "target")
+	require.NoError(t, os.Mkdir(target, 0o755))
+	marker := filepath.Join(target, "marker")
+	require.NoError(t, os.WriteFile(marker, []byte("unchanged"), 0o644))
+	if err := os.Symlink(target, filepath.Join(home, userCacheSecretDirName)); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+
+	require.NotEmpty(t, resolveUserCacheSecret("", false))
+	requireFileMode(t, target, 0o755)
+	got, err := os.ReadFile(marker)
+	require.NoError(t, err)
+	require.Equal(t, []byte("unchanged"), got)
+	_, err = os.Lstat(filepath.Join(target, userCacheSecretFileName))
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestUserCacheSecretRejectsNonRegularFilesWithoutChmod(t *testing.T) {
+	unsetUserCacheSecretEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, userCacheSecretDirName)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	nonRegular := filepath.Join(dir, userCacheSecretFileName)
+	require.NoError(t, os.Mkdir(nonRegular, 0o755))
+
+	require.NotEmpty(t, resolveUserCacheSecret("", false))
+	requireFileMode(t, nonRegular, 0o755)
+}


### PR DESCRIPTION
## Summary
- publish complete cache secrets through atomic hard-link election
- reject unusable persistence state without rewriting or following it
- support versionless eligible endpoints and preserve unsupported request bodies
- add persistence, concurrency, file-type, UTF-8, and transport regression tests

## Validation
- `go vet ./...`
- `go build -v ./...`
- `go test -race -p 1 -count=1 ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns prompt cache scoping with the spec and hardens persistence. Atomic on-disk election, safer file handling, and precise request injection for eligible endpoints (with or without /v1).

- **Bug Fixes**
  - Persistence: write to a temp file and elect via hard link; all processes adopt one value; do not rewrite blank or invalid UTF-8 files; fall back to an ephemeral secret on errors.
  - File safety: ensure the secret directory is a real directory; reject symlinks and non-regular files; do not chmod existing paths; keep current permissions intact.
  - Transport: accept `/chat/completions`, `/completions`, `/responses` with or without `/v1`; skip unsupported endpoints; skip when the body isn’t replayable (`GetBody` is nil); forward invalid UTF-8 or non-object bodies unchanged; never overwrite an existing field.
  - Tests: add regression tests for persistence, concurrency, file types, UTF-8 handling, and transport behavior.

<sup>Written for commit 07f3eb69f1ef9719bf223c2713e1577e39a95fec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-go/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

