### PR TITLE
Composable transport layer

### DIFF
--- a/ehbp_transport.go
+++ b/ehbp_transport.go
@@ -101,6 +101,21 @@ func WithOpenAIOptions(opts ...option.RequestOption) ClientOption {
 // functional options. By default it selects a router automatically, verifies
 // against the default config repository, and uses the EHBP transport.
 func NewClientWithOptions(opts ...ClientOption) (*Client, error) {
+	cfg, err := newClientConfig(opts)
+	if err != nil {
+		return nil, err
+	}
+	secureClient, err := newSecureClientFromConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return createClientFromSecureClient(secureClient, cfg.transport, cfg.baseURL,
+		ResolveUserCacheSecret(cfg.userCacheSecret, cfg.userCacheSecretSet), cfg.openaiOpts...)
+}
+
+// newClientConfig applies the options over the defaults and validates the
+// resulting configuration.
+func newClientConfig(opts []ClientOption) (*clientConfig, error) {
 	cfg := &clientConfig{
 		repo:      defaultConfigRepo,
 		transport: defaultTransportMode,
@@ -121,26 +136,28 @@ func NewClientWithOptions(opts ...ClientOption) (*Client, error) {
 			return nil, fmt.Errorf("invalid base URL: %w", err)
 		}
 	}
+	return cfg, nil
+}
 
-	var secureClient *client.SecureClient
+// newSecureClientFromConfig builds the secure client for the configured
+// enclave, selecting a router automatically when none is pinned.
+func newSecureClientFromConfig(cfg *clientConfig) (*client.SecureClient, error) {
 	switch {
 	case cfg.attestationBundleURL != "":
 		// The verified bundle supplies the enclave host, so the router lookup
 		// in NewDefaultClient is unnecessary even when no enclave is set.
-		secureClient = client.NewSecureClient(cfg.enclave, cfg.repo)
+		secureClient := client.NewSecureClient(cfg.enclave, cfg.repo)
 		secureClient.SetAttestationBundleURL(cfg.attestationBundleURL)
+		return secureClient, nil
 	case cfg.enclave == "":
-		var err error
-		secureClient, err = client.NewDefaultClient()
+		secureClient, err := client.NewDefaultClient()
 		if err != nil {
 			return nil, fmt.Errorf("failed to create secure client: %w", err)
 		}
+		return secureClient, nil
 	default:
-		secureClient = client.NewSecureClient(cfg.enclave, cfg.repo)
+		return client.NewSecureClient(cfg.enclave, cfg.repo), nil
 	}
-
-	return createClientFromSecureClient(secureClient, cfg.transport, cfg.baseURL,
-		ResolveUserCacheSecret(cfg.userCacheSecret, cfg.userCacheSecretSet), cfg.openaiOpts...)
 }
 
 // secureHTTPClient builds an *http.Client for the requested transport mode.
@@ -150,6 +167,35 @@ func NewClientWithOptions(opts ...ClientOption) (*Client, error) {
 // them in transit, but sending them to another origin would disclose them to
 // that endpoint. Requests to any other origin are therefore refused.
 func secureHTTPClient(secureClient *client.SecureClient, mode TransportMode, baseURL, userCacheSecret string) (*http.Client, error) {
+	httpClient, err := sealingHTTPClient(secureClient, mode, baseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// The cache-secret layer sits above the sealing transport, so the field it
+	// injects is encrypted with the rest of the body (EHBP) or sent over the
+	// pinned connection (TLS).
+	transport := httpClient.Transport
+	if userCacheSecret != "" {
+		transport = &userCacheSecretTransport{
+			secret:    userCacheSecret,
+			transport: transport,
+		}
+	}
+
+	guarded, err := NewHostBoundTransport(secureClient.Enclave(), baseURL, transport)
+	if err != nil {
+		return nil, err
+	}
+	httpClient.Transport = guarded
+	return httpClient, nil
+}
+
+// sealingHTTPClient builds the HTTP client for the requested transport mode:
+// pinned TLS or EHBP, both re-verifying attestation automatically when the
+// enclave rotates its keys. The returned client carries no cache-secret or
+// origin-binding layers.
+func sealingHTTPClient(secureClient *client.SecureClient, mode TransportMode, baseURL string) (*http.Client, error) {
 	var (
 		httpClient *http.Client
 		err        error
@@ -170,28 +216,25 @@ func secureHTTPClient(secureClient *client.SecureClient, mode TransportMode, bas
 			return nil, err
 		}
 	}
+	return httpClient, nil
+}
 
-	// The cache-secret layer sits above the sealing transport, so the field it
-	// injects is encrypted with the rest of the body (EHBP) or sent over the
-	// pinned connection (TLS).
-	transport := httpClient.Transport
-	if userCacheSecret != "" {
-		transport = &userCacheSecretTransport{
-			secret:    userCacheSecret,
-			transport: transport,
-		}
-	}
-
-	origins, err := allowedOrigins(secureClient.Enclave(), baseURL)
+// NewHostBoundTransport wraps rt so requests may only target the verified
+// enclave's HTTPS origin and, when baseURL is non-empty, the base URL's
+// origin. Requests to any other origin are refused before credentials or
+// request bodies are sent. Consumers composing their own stack on top of a
+// VerifiedTransport should place layers that mutate requests inside this
+// guard.
+func NewHostBoundTransport(enclave, baseURL string, rt http.RoundTripper) (http.RoundTripper, error) {
+	origins, err := allowedOrigins(enclave, baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine allowed request origins: %w", err)
 	}
-	httpClient.Transport = &hostBoundRoundTripper{
+	return &hostBoundRoundTripper{
 		allowedOrigins: origins,
-		enclave:        secureClient.Enclave(),
-		transport:      transport,
-	}
-	return httpClient, nil
+		enclave:        enclave,
+		transport:      rt,
+	}, nil
 }
 
 // allowedOrigins returns the set of origins a secured request may target: the

--- a/ehbp_transport.go
+++ b/ehbp_transport.go
@@ -140,7 +140,7 @@ func NewClientWithOptions(opts ...ClientOption) (*Client, error) {
 	}
 
 	return createClientFromSecureClient(secureClient, cfg.transport, cfg.baseURL,
-		resolveUserCacheSecret(cfg.userCacheSecret, cfg.userCacheSecretSet), cfg.openaiOpts...)
+		ResolveUserCacheSecret(cfg.userCacheSecret, cfg.userCacheSecretSet), cfg.openaiOpts...)
 }
 
 // secureHTTPClient builds an *http.Client for the requested transport mode.

--- a/ehbp_transport.go
+++ b/ehbp_transport.go
@@ -226,6 +226,9 @@ func sealingHTTPClient(secureClient *client.SecureClient, mode TransportMode, ba
 // VerifiedTransport should place layers that mutate requests inside this
 // guard.
 func NewHostBoundTransport(enclave, baseURL string, rt http.RoundTripper) (http.RoundTripper, error) {
+	if rt == nil {
+		return nil, fmt.Errorf("transport is required")
+	}
 	origins, err := allowedOrigins(enclave, baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine allowed request origins: %w", err)
@@ -285,11 +288,26 @@ func tlsPinnedHTTPClient(secureClient *client.SecureClient) (*http.Client, error
 	}
 
 	// Wrap with re-verifying transport to handle certificate rotation
-	httpClient.Transport = &reVerifyingTransport{
-		secureClient: secureClient,
-		transport:    httpClient.Transport,
-	}
+	httpClient.Transport = newTLSReVerifyingTransport(secureClient, httpClient.Transport)
 	return httpClient, nil
+}
+
+func newTLSReVerifyingTransport(secureClient *client.SecureClient, inner http.RoundTripper) *reVerifyingTransport {
+	return &reVerifyingTransport{
+		transport: inner,
+		reverify: func() (http.RoundTripper, error) {
+			// Reuse the configured client so attestation-bundle and
+			// pinned-measurement settings remain in force during rotation.
+			if _, err := secureClient.Verify(); err != nil {
+				return nil, err
+			}
+			httpClient, err := secureClient.HTTPClient()
+			if err != nil {
+				return nil, err
+			}
+			return httpClient.Transport, nil
+		},
+	}
 }
 
 // ehbpHTTPClient returns an HTTP client whose request bodies are encrypted to
@@ -441,11 +459,33 @@ func buildEHBPTransport(hpkePublicKeyHex string) (http.RoundTripper, error) {
 		return nil, fmt.Errorf("failed to parse HPKE public key: %w", err)
 	}
 
-	transport, err := ehbpclient.NewTransportWithIdentity(serverIdentity)
+	transport, err := ehbpclient.NewTransportWithIdentity(
+		serverIdentity,
+		ehbpclient.WithHTTPClient(&http.Client{
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create EHBP transport: %w", err)
 	}
-	return transport, nil
+	return &noBodyReplayTransport{transport: transport}, nil
+}
+
+// noBodyReplayTransport prevents the EHBP transport's nested http.Client from
+// replaying the caller's plaintext GetBody after EncryptRequestWithContext has
+// replaced Body with ciphertext. The outer re-verifying transport retains the
+// original request and can still replay it through fresh EHBP encryption after
+// an attested key rotation.
+type noBodyReplayTransport struct {
+	transport http.RoundTripper
+}
+
+func (t *noBodyReplayTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	out := req.Clone(req.Context())
+	out.GetBody = nil
+	return t.transport.RoundTrip(out)
 }
 
 // ehbpReVerifyingTransport wraps an EHBP round tripper and re-verifies

--- a/ehbp_transport.go
+++ b/ehbp_transport.go
@@ -154,10 +154,17 @@ func newSecureClientFromConfig(cfg *clientConfig) (*client.SecureClient, error) 
 		if err != nil {
 			return nil, fmt.Errorf("failed to create secure client: %w", err)
 		}
-		return secureClient, nil
+		return secureClientForRepo(secureClient, cfg.repo), nil
 	default:
 		return client.NewSecureClient(cfg.enclave, cfg.repo), nil
 	}
+}
+
+func secureClientForRepo(secureClient *client.SecureClient, repo string) *client.SecureClient {
+	if repo == defaultConfigRepo {
+		return secureClient
+	}
+	return client.NewSecureClient(secureClient.Enclave(), repo)
 }
 
 // secureHTTPClient builds an *http.Client for the requested transport mode.

--- a/ehbp_transport.go
+++ b/ehbp_transport.go
@@ -110,7 +110,7 @@ func NewClientWithOptions(opts ...ClientOption) (*Client, error) {
 		return nil, err
 	}
 	return createClientFromSecureClient(secureClient, cfg.transport, cfg.baseURL,
-		ResolveUserCacheSecret(cfg.userCacheSecret, cfg.userCacheSecretSet), cfg.openaiOpts...)
+		resolveUserCacheSecret(cfg.userCacheSecret, cfg.userCacheSecretSet), cfg.openaiOpts...)
 }
 
 // newClientConfig applies the options over the defaults and validates the
@@ -183,7 +183,7 @@ func secureHTTPClient(secureClient *client.SecureClient, mode TransportMode, bas
 		}
 	}
 
-	guarded, err := NewHostBoundTransport(secureClient.Enclave(), baseURL, transport)
+	guarded, err := newHostBoundTransport(secureClient.Enclave(), baseURL, transport)
 	if err != nil {
 		return nil, err
 	}
@@ -219,13 +219,11 @@ func sealingHTTPClient(secureClient *client.SecureClient, mode TransportMode, ba
 	return httpClient, nil
 }
 
-// NewHostBoundTransport wraps rt so requests may only target the verified
+// newHostBoundTransport wraps rt so requests may only target the verified
 // enclave's HTTPS origin and, when baseURL is non-empty, the base URL's
 // origin. Requests to any other origin are refused before credentials or
-// request bodies are sent. Consumers composing their own stack on top of a
-// VerifiedTransport should place layers that mutate requests inside this
-// guard.
-func NewHostBoundTransport(enclave, baseURL string, rt http.RoundTripper) (http.RoundTripper, error) {
+// request bodies are sent.
+func newHostBoundTransport(enclave, baseURL string, rt http.RoundTripper) (http.RoundTripper, error) {
 	if rt == nil {
 		return nil, fmt.Errorf("transport is required")
 	}

--- a/ehbp_transport_test.go
+++ b/ehbp_transport_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -134,6 +136,62 @@ func TestEnclaveURLHeaderValue(t *testing.T) {
 			require.Equal(t, tt.wantVal, val)
 		})
 	}
+}
+
+func TestEHBPTransportDoesNotFollowRedirects(t *testing.T) {
+	redirected := make(chan string, 1)
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		redirected <- string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	serverIdentity, err := ehbpidentity.NewIdentity()
+	require.NoError(t, err)
+	source := httptest.NewServer(serverIdentity.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		http.Redirect(w, req, target.URL, http.StatusTemporaryRedirect)
+	})))
+	defer source.Close()
+
+	transport, err := buildEHBPTransport(serverIdentity.MarshalPublicKeyHex())
+	require.NoError(t, err)
+	guarded, err := NewHostBoundTransport("", source.URL, transport)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, source.URL, strings.NewReader("cache-secret-and-prompt"))
+	require.NoError(t, err)
+	resp, err := guarded.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+
+	select {
+	case body := <-redirected:
+		t.Fatalf("redirect leaked request body to a foreign origin: %q", body)
+	default:
+	}
+}
+
+func TestNoBodyReplayTransportClearsGetBody(t *testing.T) {
+	inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		require.Nil(t, req.GetBody)
+		return newResponse(http.StatusOK, "{}"), nil
+	})
+	transport := &noBodyReplayTransport{transport: inner}
+
+	req, err := http.NewRequest(http.MethodPost, "https://enclave.example.com/v1/responses", strings.NewReader("prompt"))
+	require.NoError(t, err)
+	require.NotNil(t, req.GetBody)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.NotNil(t, req.GetBody, "the caller's request must remain replayable for attested key rotation")
 }
 
 func TestEnclaveURLHeaderTransportInjectsHeader(t *testing.T) {

--- a/ehbp_transport_test.go
+++ b/ehbp_transport_test.go
@@ -160,7 +160,7 @@ func TestEHBPTransportDoesNotFollowRedirects(t *testing.T) {
 
 	transport, err := buildEHBPTransport(serverIdentity.MarshalPublicKeyHex())
 	require.NoError(t, err)
-	guarded, err := NewHostBoundTransport("", source.URL, transport)
+	guarded, err := newHostBoundTransport("", source.URL, transport)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPost, source.URL, strings.NewReader("cache-secret-and-prompt"))

--- a/ehbp_transport_test.go
+++ b/ehbp_transport_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	ehbpidentity "github.com/tinfoilsh/encrypted-http-body-protocol/identity"
+	"github.com/tinfoilsh/tinfoil-go/verifier/client"
 )
 
 // roundTripFunc adapts a function to an http.RoundTripper.
@@ -68,6 +69,17 @@ func TestProxyClientOptionsApply(t *testing.T) {
 	require.Equal(t, "https://proxy.example.com/", cfg.baseURL)
 	require.True(t, cfg.baseURLSet)
 	require.Equal(t, "https://proxy.example.com", cfg.attestationBundleURL)
+}
+
+func TestSecureClientForRepo(t *testing.T) {
+	selected := client.NewSecureClient("router.example.com", defaultConfigRepo)
+
+	require.Same(t, selected, secureClientForRepo(selected, defaultConfigRepo))
+
+	custom := secureClientForRepo(selected, "org/custom-router")
+	require.NotSame(t, selected, custom)
+	require.Equal(t, selected.Enclave(), custom.Enclave())
+	require.Equal(t, "org/custom-router", custom.Repo())
 }
 
 func TestNewClientWithOptionsRejectsInvalidBaseURL(t *testing.T) {

--- a/tinfoil_client.go
+++ b/tinfoil_client.go
@@ -77,7 +77,7 @@ type Client struct {
 // NewClientWithParams creates a new secure OpenAI client with explicit enclave and repo parameters
 func NewClientWithParams(enclave, repo string, openaiOpts ...option.RequestOption) (*Client, error) {
 	secureClient := client.NewSecureClient(enclave, repo)
-	return createClientFromSecureClient(secureClient, defaultTransportMode, "", resolveUserCacheSecret("", false), openaiOpts...)
+	return createClientFromSecureClient(secureClient, defaultTransportMode, "", ResolveUserCacheSecret("", false), openaiOpts...)
 }
 
 // NewClient creates a new secure OpenAI client using default parameters
@@ -86,7 +86,7 @@ func NewClient(openaiOpts ...option.RequestOption) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create secure client: %w", err)
 	}
-	return createClientFromSecureClient(secureClient, defaultTransportMode, "", resolveUserCacheSecret("", false), openaiOpts...)
+	return createClientFromSecureClient(secureClient, defaultTransportMode, "", ResolveUserCacheSecret("", false), openaiOpts...)
 }
 
 // createClientFromSecureClient is a helper function to create a Client from a SecureClient

--- a/tinfoil_client.go
+++ b/tinfoil_client.go
@@ -101,7 +101,7 @@ type Client struct {
 // NewClientWithParams creates a new secure OpenAI client with explicit enclave and repo parameters
 func NewClientWithParams(enclave, repo string, openaiOpts ...option.RequestOption) (*Client, error) {
 	secureClient := client.NewSecureClient(enclave, repo)
-	return createClientFromSecureClient(secureClient, defaultTransportMode, "", ResolveUserCacheSecret("", false), openaiOpts...)
+	return createClientFromSecureClient(secureClient, defaultTransportMode, "", DefaultUserCacheSecret(), openaiOpts...)
 }
 
 // NewClient creates a new secure OpenAI client using default parameters
@@ -110,7 +110,7 @@ func NewClient(openaiOpts ...option.RequestOption) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create secure client: %w", err)
 	}
-	return createClientFromSecureClient(secureClient, defaultTransportMode, "", ResolveUserCacheSecret("", false), openaiOpts...)
+	return createClientFromSecureClient(secureClient, defaultTransportMode, "", DefaultUserCacheSecret(), openaiOpts...)
 }
 
 // createClientFromSecureClient is a helper function to create a Client from a SecureClient

--- a/tinfoil_client.go
+++ b/tinfoil_client.go
@@ -17,14 +17,18 @@ import (
 // reVerifyingTransport wraps an http.RoundTripper and automatically re-verifies
 // attestation on certificate errors, handling server certificate rotation.
 type reVerifyingTransport struct {
-	secureClient *client.SecureClient
-	mu           sync.RWMutex
-	transport    http.RoundTripper
+	mu         sync.RWMutex
+	transport  http.RoundTripper
+	generation uint64
+
+	reverifyMu sync.Mutex
+	reverify   func() (http.RoundTripper, error)
 }
 
 func (t *reVerifyingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	t.mu.RLock()
 	transport := t.transport
+	generation := t.generation
 	t.mu.RUnlock()
 
 	resp, err := transport.RoundTrip(req)
@@ -32,23 +36,43 @@ func (t *reVerifyingTransport) RoundTrip(req *http.Request) (*http.Response, err
 		return resp, err
 	}
 
-	// Certificate error detected, reinitialize secure client to re-verify attestation
-	newSecureClient := client.NewSecureClient(t.secureClient.Enclave(), t.secureClient.Repo())
-	newHTTPClient, clientErr := newSecureClient.HTTPClient()
-	if clientErr != nil {
-		// Re-verification failed, connection is genuinely malicious
+	retryReq, bodyErr := resetRequestBody(req)
+	if bodyErr != nil {
 		return nil, err
 	}
 
-	// Re-verification succeeded, update transport and retry
-	log.Info("Certificate rotation detected, re-verified attestation successfully")
+	newTransport, reverifyErr := t.reverifyOnce(generation)
+	if reverifyErr != nil {
+		// Re-verification failed, connection is genuinely malicious.
+		return nil, err
+	}
+
+	return newTransport.RoundTrip(retryReq)
+}
+
+func (t *reVerifyingTransport) reverifyOnce(seenGeneration uint64) (http.RoundTripper, error) {
+	t.reverifyMu.Lock()
+	defer t.reverifyMu.Unlock()
+
+	t.mu.RLock()
+	current, currentGeneration := t.transport, t.generation
+	t.mu.RUnlock()
+	if currentGeneration != seenGeneration {
+		return current, nil
+	}
+
+	newTransport, err := t.reverify()
+	if err != nil {
+		return nil, err
+	}
 
 	t.mu.Lock()
-	t.secureClient = newSecureClient
-	t.transport = newHTTPClient.Transport
+	t.transport = newTransport
+	t.generation++
 	t.mu.Unlock()
 
-	return newHTTPClient.Transport.RoundTrip(req)
+	log.Info("Certificate rotation detected, re-verified attestation successfully")
+	return newTransport, nil
 }
 
 func isCertificateError(err error) bool {

--- a/tinfoil_client_test.go
+++ b/tinfoil_client_test.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
+	"io"
+	"net/http"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/openai/openai-go/v3"
@@ -294,5 +298,87 @@ func TestIsCertificateError(t *testing.T) {
 			result := isCertificateError(tt.err)
 			require.Equal(t, tt.expected, result)
 		})
+	}
+}
+
+func TestTLSReverificationPreservesAttestationBundleURL(t *testing.T) {
+	secureClient := client.NewSecureClient("enclave.example.com", "org/repo")
+	secureClient.SetAttestationBundleURL("https://127.0.0.1:1")
+
+	transport := newTLSReVerifyingTransport(secureClient, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, client.ErrCertMismatch
+	}))
+	_, err := transport.reverify()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "fetchBundle",
+		"TLS re-verification must retain the configured bundle endpoint")
+}
+
+func TestTLSReverificationRunsOnceAndReplaysBodies(t *testing.T) {
+	const workers = 8
+
+	var arrived sync.WaitGroup
+	arrived.Add(workers)
+	release := make(chan struct{})
+	stale := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		arrived.Done()
+		<-release
+		if _, err := io.ReadAll(req.Body); err != nil {
+			return nil, err
+		}
+		return nil, client.ErrCertMismatch
+	})
+
+	var reverifyCalls atomic.Int64
+	freshBodies := make(chan string, workers)
+	fresh := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		freshBodies <- string(body)
+		return newResponse(http.StatusOK, "{}"), nil
+	})
+
+	transport := &reVerifyingTransport{
+		transport: stale,
+		reverify: func() (http.RoundTripper, error) {
+			reverifyCalls.Add(1)
+			return fresh, nil
+		},
+	}
+
+	var requests sync.WaitGroup
+	requests.Add(workers)
+	errs := make(chan error, workers)
+	for range workers {
+		go func() {
+			defer requests.Done()
+			req, err := http.NewRequest(http.MethodPost, "https://enclave.example.com/v1/responses", strings.NewReader("prompt"))
+			if err != nil {
+				errs <- err
+				return
+			}
+			resp, err := transport.RoundTrip(req)
+			if resp != nil {
+				resp.Body.Close()
+			}
+			errs <- err
+		}()
+	}
+
+	arrived.Wait()
+	close(release)
+	requests.Wait()
+	close(errs)
+	close(freshBodies)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Equal(t, int64(1), reverifyCalls.Load())
+	require.Equal(t, workers, len(freshBodies))
+	for body := range freshBodies {
+		require.Equal(t, "prompt", body)
 	}
 }

--- a/tinfoil_client_test.go
+++ b/tinfoil_client_test.go
@@ -189,7 +189,7 @@ func TestDirectClientStreamingChat(t *testing.T) {
 }
 
 func TestHTTPClient(t *testing.T) {
-	t.Setenv(userCacheSecretEnv, "test-secret")
+	t.Setenv(UserCacheSecretEnv, "test-secret")
 	client, err := NewClient()
 	require.NoError(t, err)
 

--- a/user_cache_secret.go
+++ b/user_cache_secret.go
@@ -39,16 +39,16 @@ import (
 // body, so the secret is only ever visible to the verified enclave.
 
 const (
-	// userCacheSecretField is the router-only request-body field. A non-empty
+	// UserCacheSecretField is the router-only request-body field. A non-empty
 	// string scopes the prompt cache to that secret; an absent or empty value
 	// leaves the request in the tenant-wide namespace.
-	userCacheSecretField = "user_cache_secret"
+	UserCacheSecretField = "user_cache_secret"
 
-	// userCacheSecretEnv provisions the secret via the environment. Setting it
+	// UserCacheSecretEnv provisions the secret via the environment. Setting it
 	// to an empty string disables generation entirely (tenant-wide caching),
 	// which is the right call for pooled multi-user deployments that would
 	// otherwise mint a fresh namespace per container.
-	userCacheSecretEnv = "TINFOIL_USER_CACHE_SECRET"
+	UserCacheSecretEnv = "TINFOIL_USER_CACHE_SECRET"
 
 	// userCacheSecretFile is the persisted-secret path under the home
 	// directory. The other Tinfoil SDKs use the same file, so one machine gets
@@ -85,14 +85,14 @@ func WithUserCacheSecret(secret string) ClientOption {
 	}
 }
 
-// resolveUserCacheSecret resolves the client-level secret: the explicit option
+// ResolveUserCacheSecret resolves the client-level secret: the explicit option
 // wins, then the environment, then the persisted (or generated) secret. An
 // empty result means injection is disabled.
-func resolveUserCacheSecret(explicit string, explicitSet bool) string {
+func ResolveUserCacheSecret(explicit string, explicitSet bool) string {
 	if explicitSet {
 		return explicit
 	}
-	if env, ok := os.LookupEnv(userCacheSecretEnv); ok {
+	if env, ok := os.LookupEnv(UserCacheSecretEnv); ok {
 		return env
 	}
 	return loadOrGenerateUserCacheSecret()
@@ -118,7 +118,7 @@ func newUserCacheSecret() string {
 var ephemeralUserCacheSecret = sync.OnceValue(func() string {
 	secret := newUserCacheSecret()
 	if secret != "" {
-		log.Warnf("tinfoil: could not persist the user cache secret; using an in-memory secret, so prompt-cache continuity resets when this process exits (set %s or WithUserCacheSecret to pin one)", userCacheSecretEnv)
+		log.Warnf("tinfoil: could not persist the user cache secret; using an in-memory secret, so prompt-cache continuity resets when this process exits (set %s or WithUserCacheSecret to pin one)", UserCacheSecretEnv)
 	}
 	return secret
 })
@@ -264,7 +264,7 @@ type userCacheSecretTransport struct {
 }
 
 func (t *userCacheSecretTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if t.secret == "" || !userCacheSecretPathEligible(req) || req.GetBody == nil {
+	if t.secret == "" || !UserCacheSecretPathEligible(req) || req.GetBody == nil {
 		return t.transport.RoundTrip(req)
 	}
 
@@ -274,7 +274,7 @@ func (t *userCacheSecretTransport) RoundTrip(req *http.Request) (*http.Response,
 		return nil, err
 	}
 
-	newBody, changed := injectUserCacheSecret(raw, t.secret)
+	newBody, changed := InjectUserCacheSecret(raw, t.secret)
 	out := req.Clone(req.Context())
 	if !changed {
 		// Not a JSON object, or the caller set the field: forward the
@@ -294,9 +294,9 @@ func (t *userCacheSecretTransport) RoundTrip(req *http.Request) (*http.Response,
 	return t.transport.RoundTrip(out)
 }
 
-// userCacheSecretPathEligible reports whether the request can carry the field:
+// UserCacheSecretPathEligible reports whether the request can carry the field:
 // a POST with a body to one of the supported endpoints.
-func userCacheSecretPathEligible(req *http.Request) bool {
+func UserCacheSecretPathEligible(req *http.Request) bool {
 	if req.Method != http.MethodPost || req.Body == nil || req.Body == http.NoBody {
 		return false
 	}
@@ -308,12 +308,12 @@ func userCacheSecretPathEligible(req *http.Request) bool {
 	return false
 }
 
-// injectUserCacheSecret adds the field to a JSON-object body, preserving
+// InjectUserCacheSecret adds the field to a JSON-object body, preserving
 // number precision across the re-marshal (float64 round-tripping would corrupt
 // int64-range values such as seed). It reports false — forward the original
 // bytes — for non-object bodies, trailing data, or a body that already carries
 // the field.
-func injectUserCacheSecret(raw []byte, secret string) ([]byte, bool) {
+func InjectUserCacheSecret(raw []byte, secret string) ([]byte, bool) {
 	if !utf8.Valid(raw) {
 		return nil, false
 	}
@@ -323,10 +323,10 @@ func injectUserCacheSecret(raw []byte, secret string) ([]byte, bool) {
 	if err := dec.Decode(&body); err != nil || !decodeConsumedAll(dec) || body == nil {
 		return nil, false
 	}
-	if _, ok := body[userCacheSecretField]; ok {
+	if _, ok := body[UserCacheSecretField]; ok {
 		return nil, false
 	}
-	body[userCacheSecretField] = secret
+	body[UserCacheSecretField] = secret
 	newBody, err := json.Marshal(body)
 	if err != nil {
 		return nil, false

--- a/user_cache_secret.go
+++ b/user_cache_secret.go
@@ -85,13 +85,20 @@ func WithUserCacheSecret(secret string) ClientOption {
 	}
 }
 
-// ResolveUserCacheSecret resolves the client-level secret: the explicit option
-// wins, then the environment, then the persisted (or generated) secret. An
-// empty result means injection is disabled.
-func ResolveUserCacheSecret(explicit string, explicitSet bool) string {
+// resolveUserCacheSecret applies an explicit client option before the default
+// resolution chain.
+func resolveUserCacheSecret(explicit string, explicitSet bool) string {
 	if explicitSet {
 		return explicit
 	}
+	return DefaultUserCacheSecret()
+}
+
+// DefaultUserCacheSecret resolves the environment-provided or persisted
+// machine-level secret. If neither exists, it generates and persists a secret.
+// An environment variable that is present but empty disables generation and
+// injection.
+func DefaultUserCacheSecret() string {
 	if env, ok := os.LookupEnv(UserCacheSecretEnv); ok {
 		return env
 	}

--- a/user_cache_secret_test.go
+++ b/user_cache_secret_test.go
@@ -26,8 +26,8 @@ import (
 // developer .env loaded by TestMain may set it) and restores it afterwards.
 func unsetUserCacheSecretEnv(t *testing.T) {
 	t.Helper()
-	t.Setenv(userCacheSecretEnv, "placeholder") // registers restoration
-	require.NoError(t, os.Unsetenv(userCacheSecretEnv))
+	t.Setenv(UserCacheSecretEnv, "placeholder") // registers restoration
+	require.NoError(t, os.Unsetenv(UserCacheSecretEnv))
 }
 
 func TestWithUserCacheSecretOption(t *testing.T) {
@@ -47,25 +47,25 @@ func TestResolveUserCacheSecretPrecedence(t *testing.T) {
 	t.Setenv("HOME", home)
 
 	t.Run("explicit option beats environment", func(t *testing.T) {
-		t.Setenv(userCacheSecretEnv, "from-env")
-		require.Equal(t, "explicit", resolveUserCacheSecret("explicit", true))
+		t.Setenv(UserCacheSecretEnv, "from-env")
+		require.Equal(t, "explicit", ResolveUserCacheSecret("explicit", true))
 	})
 
 	t.Run("explicit empty disables even with environment set", func(t *testing.T) {
-		t.Setenv(userCacheSecretEnv, "from-env")
-		require.Empty(t, resolveUserCacheSecret("", true))
+		t.Setenv(UserCacheSecretEnv, "from-env")
+		require.Empty(t, ResolveUserCacheSecret("", true))
 	})
 
 	t.Run("environment beats generation and touches no file", func(t *testing.T) {
-		t.Setenv(userCacheSecretEnv, "from-env")
-		require.Equal(t, "from-env", resolveUserCacheSecret("", false))
+		t.Setenv(UserCacheSecretEnv, "from-env")
+		require.Equal(t, "from-env", ResolveUserCacheSecret("", false))
 		_, err := os.Stat(filepath.Join(home, userCacheSecretDirName))
 		require.True(t, os.IsNotExist(err), "an environment-provided secret must not create the secret file")
 	})
 
 	t.Run("environment set but empty disables generation", func(t *testing.T) {
-		t.Setenv(userCacheSecretEnv, "")
-		require.Empty(t, resolveUserCacheSecret("", false))
+		t.Setenv(UserCacheSecretEnv, "")
+		require.Empty(t, ResolveUserCacheSecret("", false))
 		_, err := os.Stat(filepath.Join(home, userCacheSecretDirName))
 		require.True(t, os.IsNotExist(err), "a disabled secret must not create the secret file")
 	})
@@ -76,7 +76,7 @@ func TestUserCacheSecretGenerateAndPersist(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	first := resolveUserCacheSecret("", false)
+	first := ResolveUserCacheSecret("", false)
 	require.Len(t, first, 64, "expected a hex-encoded 256-bit secret")
 
 	path := filepath.Join(home, userCacheSecretDirName, userCacheSecretFileName)
@@ -86,7 +86,7 @@ func TestUserCacheSecretGenerateAndPersist(t *testing.T) {
 
 	// A second resolution (a new client, or another SDK on the same machine)
 	// must reuse the persisted secret, not mint a new namespace.
-	require.Equal(t, first, resolveUserCacheSecret("", false))
+	require.Equal(t, first, ResolveUserCacheSecret("", false))
 }
 
 func TestUserCacheSecretAdoptsExistingFile(t *testing.T) {
@@ -99,7 +99,7 @@ func TestUserCacheSecretAdoptsExistingFile(t *testing.T) {
 	// Trailing newline: the file may be hand-edited or written by another SDK.
 	require.NoError(t, os.WriteFile(filepath.Join(dir, userCacheSecretFileName), []byte("shared-secret\n"), 0o600))
 
-	require.Equal(t, "shared-secret", resolveUserCacheSecret("", false))
+	require.Equal(t, "shared-secret", ResolveUserCacheSecret("", false))
 }
 
 func TestUserCacheSecretRejectsInvalidUTF8WithoutRewriting(t *testing.T) {
@@ -113,9 +113,9 @@ func TestUserCacheSecretRejectsInvalidUTF8WithoutRewriting(t *testing.T) {
 	require.NoError(t, os.MkdirAll(dir, 0o700))
 	require.NoError(t, os.WriteFile(path, corrupted, 0o600))
 
-	first := resolveUserCacheSecret("", false)
+	first := ResolveUserCacheSecret("", false)
 	require.Len(t, first, 64)
-	require.Equal(t, first, resolveUserCacheSecret("", false))
+	require.Equal(t, first, ResolveUserCacheSecret("", false))
 	persisted, err := os.ReadFile(path)
 	require.NoError(t, err)
 	require.Equal(t, corrupted, persisted)
@@ -136,7 +136,7 @@ func TestUserCacheSecretAcceptsPermissiveExistingPermissions(t *testing.T) {
 	require.NoError(t, os.Chmod(dir, 0o777))
 	require.NoError(t, os.Chmod(path, 0o666))
 
-	require.Equal(t, "shared-secret", resolveUserCacheSecret("", false))
+	require.Equal(t, "shared-secret", ResolveUserCacheSecret("", false))
 	requireFileMode(t, dir, 0o777)
 	requireFileMode(t, path, 0o666)
 }
@@ -151,9 +151,9 @@ func TestUserCacheSecretLeavesBlankFileUntouched(t *testing.T) {
 	require.NoError(t, os.MkdirAll(dir, 0o700))
 	require.NoError(t, os.WriteFile(path, []byte("  \n"), 0o600))
 
-	first := resolveUserCacheSecret("", false)
+	first := ResolveUserCacheSecret("", false)
 	require.Len(t, first, 64)
-	require.Equal(t, first, resolveUserCacheSecret("", false))
+	require.Equal(t, first, ResolveUserCacheSecret("", false))
 	written, err := os.ReadFile(path)
 	require.NoError(t, err)
 	require.Equal(t, []byte("  \n"), written)
@@ -177,14 +177,14 @@ func TestUserCacheSecretSubprocess(t *testing.T) {
 	if os.Getenv("TINFOIL_CACHE_SECRET_HELPER") != "1" {
 		return
 	}
-	_ = os.Unsetenv(userCacheSecretEnv)
+	_ = os.Unsetenv(UserCacheSecretEnv)
 	fmt.Println("ready")
 	var release [1]byte
 	if _, err := io.ReadFull(os.Stdin, release[:]); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(2)
 	}
-	fmt.Println(resolveUserCacheSecret("", false))
+	fmt.Println(ResolveUserCacheSecret("", false))
 	os.Exit(0)
 }
 
@@ -241,7 +241,7 @@ func userCacheSecretHelperEnv(home string) []string {
 	for _, value := range os.Environ() {
 		if strings.HasPrefix(value, "HOME=") ||
 			strings.HasPrefix(value, "USERPROFILE=") ||
-			strings.HasPrefix(value, userCacheSecretEnv+"=") ||
+			strings.HasPrefix(value, UserCacheSecretEnv+"=") ||
 			strings.HasPrefix(value, "TINFOIL_CACHE_SECRET_HELPER=") {
 			continue
 		}
@@ -269,9 +269,9 @@ func TestUserCacheSecretFallsBackWithoutHome(t *testing.T) {
 	unsetUserCacheSecretEnv(t)
 	t.Setenv("HOME", "")
 
-	first := resolveUserCacheSecret("", false)
+	first := ResolveUserCacheSecret("", false)
 	require.NotEmpty(t, first, "no home directory must still yield a process-lifetime secret")
-	require.Equal(t, first, resolveUserCacheSecret("", false), "the in-memory fallback must be stable within the process")
+	require.Equal(t, first, ResolveUserCacheSecret("", false), "the in-memory fallback must be stable within the process")
 }
 
 func TestUserCacheSecretFallsBackWhenHomeNotADirectory(t *testing.T) {
@@ -280,7 +280,7 @@ func TestUserCacheSecretFallsBackWhenHomeNotADirectory(t *testing.T) {
 	require.NoError(t, os.WriteFile(homeFile, []byte("x"), 0o600))
 	t.Setenv("HOME", homeFile)
 
-	require.NotEmpty(t, resolveUserCacheSecret("", false))
+	require.NotEmpty(t, ResolveUserCacheSecret("", false))
 }
 
 // captureTransport returns a userCacheSecretTransport whose inner round
@@ -333,7 +333,7 @@ func TestUserCacheSecretTransportInjects(t *testing.T) {
 
 			var body map[string]any
 			require.NoError(t, json.Unmarshal(got, &body))
-			require.Equal(t, "s1", body[userCacheSecretField])
+			require.Equal(t, "s1", body[UserCacheSecretField])
 
 			// Length metadata and the replayable body must describe the
 			// injected bytes: retries below this layer (EHBP key rotation)
@@ -466,7 +466,7 @@ func TestUserCacheSecretTransportAllowsTrailingWhitespace(t *testing.T) {
 
 	var body map[string]any
 	require.NoError(t, json.Unmarshal(got, &body))
-	require.Equal(t, "s1", body[userCacheSecretField])
+	require.Equal(t, "s1", body[UserCacheSecretField])
 }
 
 func TestUserCacheSecretTransportPreservesNumberPrecision(t *testing.T) {
@@ -510,11 +510,11 @@ func TestUserCacheSecretThroughOpenAIClient(t *testing.T) {
 
 	_, err := oai.Chat.Completions.New(context.Background(), params)
 	require.NoError(t, err)
-	require.Equal(t, "client-level", received[userCacheSecretField])
+	require.Equal(t, "client-level", received[UserCacheSecretField])
 
 	_, err = oai.Chat.Completions.New(context.Background(), params,
-		option.WithJSONSet(userCacheSecretField, "end-user-7"))
+		option.WithJSONSet(UserCacheSecretField, "end-user-7"))
 	require.NoError(t, err)
-	require.Equal(t, "end-user-7", received[userCacheSecretField],
+	require.Equal(t, "end-user-7", received[UserCacheSecretField],
 		"a per-request field must win over the client-level secret")
 }

--- a/user_cache_secret_test.go
+++ b/user_cache_secret_test.go
@@ -42,30 +42,30 @@ func TestWithUserCacheSecretOption(t *testing.T) {
 	require.True(t, cfg.userCacheSecretSet, "an explicit empty secret must still count as set (it disables provisioning)")
 }
 
-func TestResolveUserCacheSecretPrecedence(t *testing.T) {
+func TestUserCacheSecretResolutionPrecedence(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
 	t.Run("explicit option beats environment", func(t *testing.T) {
 		t.Setenv(UserCacheSecretEnv, "from-env")
-		require.Equal(t, "explicit", ResolveUserCacheSecret("explicit", true))
+		require.Equal(t, "explicit", resolveUserCacheSecret("explicit", true))
 	})
 
 	t.Run("explicit empty disables even with environment set", func(t *testing.T) {
 		t.Setenv(UserCacheSecretEnv, "from-env")
-		require.Empty(t, ResolveUserCacheSecret("", true))
+		require.Empty(t, resolveUserCacheSecret("", true))
 	})
 
 	t.Run("environment beats generation and touches no file", func(t *testing.T) {
 		t.Setenv(UserCacheSecretEnv, "from-env")
-		require.Equal(t, "from-env", ResolveUserCacheSecret("", false))
+		require.Equal(t, "from-env", DefaultUserCacheSecret())
 		_, err := os.Stat(filepath.Join(home, userCacheSecretDirName))
 		require.True(t, os.IsNotExist(err), "an environment-provided secret must not create the secret file")
 	})
 
 	t.Run("environment set but empty disables generation", func(t *testing.T) {
 		t.Setenv(UserCacheSecretEnv, "")
-		require.Empty(t, ResolveUserCacheSecret("", false))
+		require.Empty(t, DefaultUserCacheSecret())
 		_, err := os.Stat(filepath.Join(home, userCacheSecretDirName))
 		require.True(t, os.IsNotExist(err), "a disabled secret must not create the secret file")
 	})
@@ -76,7 +76,7 @@ func TestUserCacheSecretGenerateAndPersist(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	first := ResolveUserCacheSecret("", false)
+	first := DefaultUserCacheSecret()
 	require.Len(t, first, 64, "expected a hex-encoded 256-bit secret")
 
 	path := filepath.Join(home, userCacheSecretDirName, userCacheSecretFileName)
@@ -86,7 +86,7 @@ func TestUserCacheSecretGenerateAndPersist(t *testing.T) {
 
 	// A second resolution (a new client, or another SDK on the same machine)
 	// must reuse the persisted secret, not mint a new namespace.
-	require.Equal(t, first, ResolveUserCacheSecret("", false))
+	require.Equal(t, first, DefaultUserCacheSecret())
 }
 
 func TestUserCacheSecretAdoptsExistingFile(t *testing.T) {
@@ -99,7 +99,7 @@ func TestUserCacheSecretAdoptsExistingFile(t *testing.T) {
 	// Trailing newline: the file may be hand-edited or written by another SDK.
 	require.NoError(t, os.WriteFile(filepath.Join(dir, userCacheSecretFileName), []byte("shared-secret\n"), 0o600))
 
-	require.Equal(t, "shared-secret", ResolveUserCacheSecret("", false))
+	require.Equal(t, "shared-secret", DefaultUserCacheSecret())
 }
 
 func TestUserCacheSecretRejectsInvalidUTF8WithoutRewriting(t *testing.T) {
@@ -113,9 +113,9 @@ func TestUserCacheSecretRejectsInvalidUTF8WithoutRewriting(t *testing.T) {
 	require.NoError(t, os.MkdirAll(dir, 0o700))
 	require.NoError(t, os.WriteFile(path, corrupted, 0o600))
 
-	first := ResolveUserCacheSecret("", false)
+	first := DefaultUserCacheSecret()
 	require.Len(t, first, 64)
-	require.Equal(t, first, ResolveUserCacheSecret("", false))
+	require.Equal(t, first, DefaultUserCacheSecret())
 	persisted, err := os.ReadFile(path)
 	require.NoError(t, err)
 	require.Equal(t, corrupted, persisted)
@@ -136,7 +136,7 @@ func TestUserCacheSecretAcceptsPermissiveExistingPermissions(t *testing.T) {
 	require.NoError(t, os.Chmod(dir, 0o777))
 	require.NoError(t, os.Chmod(path, 0o666))
 
-	require.Equal(t, "shared-secret", ResolveUserCacheSecret("", false))
+	require.Equal(t, "shared-secret", DefaultUserCacheSecret())
 	requireFileMode(t, dir, 0o777)
 	requireFileMode(t, path, 0o666)
 }
@@ -151,9 +151,9 @@ func TestUserCacheSecretLeavesBlankFileUntouched(t *testing.T) {
 	require.NoError(t, os.MkdirAll(dir, 0o700))
 	require.NoError(t, os.WriteFile(path, []byte("  \n"), 0o600))
 
-	first := ResolveUserCacheSecret("", false)
+	first := DefaultUserCacheSecret()
 	require.Len(t, first, 64)
-	require.Equal(t, first, ResolveUserCacheSecret("", false))
+	require.Equal(t, first, DefaultUserCacheSecret())
 	written, err := os.ReadFile(path)
 	require.NoError(t, err)
 	require.Equal(t, []byte("  \n"), written)
@@ -184,7 +184,7 @@ func TestUserCacheSecretSubprocess(t *testing.T) {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(2)
 	}
-	fmt.Println(ResolveUserCacheSecret("", false))
+	fmt.Println(DefaultUserCacheSecret())
 	os.Exit(0)
 }
 
@@ -269,9 +269,9 @@ func TestUserCacheSecretFallsBackWithoutHome(t *testing.T) {
 	unsetUserCacheSecretEnv(t)
 	t.Setenv("HOME", "")
 
-	first := ResolveUserCacheSecret("", false)
+	first := DefaultUserCacheSecret()
 	require.NotEmpty(t, first, "no home directory must still yield a process-lifetime secret")
-	require.Equal(t, first, ResolveUserCacheSecret("", false), "the in-memory fallback must be stable within the process")
+	require.Equal(t, first, DefaultUserCacheSecret(), "the in-memory fallback must be stable within the process")
 }
 
 func TestUserCacheSecretFallsBackWhenHomeNotADirectory(t *testing.T) {
@@ -280,7 +280,7 @@ func TestUserCacheSecretFallsBackWhenHomeNotADirectory(t *testing.T) {
 	require.NoError(t, os.WriteFile(homeFile, []byte("x"), 0o600))
 	t.Setenv("HOME", homeFile)
 
-	require.NotEmpty(t, ResolveUserCacheSecret("", false))
+	require.NotEmpty(t, DefaultUserCacheSecret())
 }
 
 // captureTransport returns a userCacheSecretTransport whose inner round

--- a/user_cache_secret_unix_test.go
+++ b/user_cache_secret_unix_test.go
@@ -22,7 +22,7 @@ func TestUserCacheSecretRejectsSymlinksWithoutTouchingTargets(t *testing.T) {
 		t.Skipf("symlinks are unavailable: %v", err)
 	}
 
-	require.NotEqual(t, string(targetContents), ResolveUserCacheSecret("", false))
+	require.NotEqual(t, string(targetContents), DefaultUserCacheSecret())
 	got, err := os.ReadFile(target)
 	require.NoError(t, err)
 	require.Equal(t, targetContents, got)
@@ -42,7 +42,7 @@ func TestUserCacheSecretRejectsSymlinkDirectoryWithoutTouchingTarget(t *testing.
 		t.Skipf("symlinks are unavailable: %v", err)
 	}
 
-	require.NotEmpty(t, ResolveUserCacheSecret("", false))
+	require.NotEmpty(t, DefaultUserCacheSecret())
 	requireFileMode(t, target, 0o755)
 	got, err := os.ReadFile(marker)
 	require.NoError(t, err)
@@ -60,6 +60,6 @@ func TestUserCacheSecretRejectsNonRegularFilesWithoutChmod(t *testing.T) {
 	nonRegular := filepath.Join(dir, userCacheSecretFileName)
 	require.NoError(t, os.Mkdir(nonRegular, 0o755))
 
-	require.NotEmpty(t, ResolveUserCacheSecret("", false))
+	require.NotEmpty(t, DefaultUserCacheSecret())
 	requireFileMode(t, nonRegular, 0o755)
 }

--- a/user_cache_secret_unix_test.go
+++ b/user_cache_secret_unix_test.go
@@ -22,7 +22,7 @@ func TestUserCacheSecretRejectsSymlinksWithoutTouchingTargets(t *testing.T) {
 		t.Skipf("symlinks are unavailable: %v", err)
 	}
 
-	require.NotEqual(t, string(targetContents), resolveUserCacheSecret("", false))
+	require.NotEqual(t, string(targetContents), ResolveUserCacheSecret("", false))
 	got, err := os.ReadFile(target)
 	require.NoError(t, err)
 	require.Equal(t, targetContents, got)
@@ -42,7 +42,7 @@ func TestUserCacheSecretRejectsSymlinkDirectoryWithoutTouchingTarget(t *testing.
 		t.Skipf("symlinks are unavailable: %v", err)
 	}
 
-	require.NotEmpty(t, resolveUserCacheSecret("", false))
+	require.NotEmpty(t, ResolveUserCacheSecret("", false))
 	requireFileMode(t, target, 0o755)
 	got, err := os.ReadFile(marker)
 	require.NoError(t, err)
@@ -60,6 +60,6 @@ func TestUserCacheSecretRejectsNonRegularFilesWithoutChmod(t *testing.T) {
 	nonRegular := filepath.Join(dir, userCacheSecretFileName)
 	require.NoError(t, os.Mkdir(nonRegular, 0o755))
 
-	require.NotEmpty(t, resolveUserCacheSecret("", false))
+	require.NotEmpty(t, ResolveUserCacheSecret("", false))
 	requireFileMode(t, nonRegular, 0o755)
 }

--- a/verified_transport.go
+++ b/verified_transport.go
@@ -40,7 +40,7 @@ func newVerifiedTransport(secureClient *client.SecureClient, mode TransportMode,
 	if err != nil {
 		return nil, err
 	}
-	transport, err := NewHostBoundTransport(secureClient.Enclave(), baseURL, httpClient.Transport)
+	transport, err := newHostBoundTransport(secureClient.Enclave(), baseURL, httpClient.Transport)
 	if err != nil {
 		return nil, err
 	}

--- a/verified_transport.go
+++ b/verified_transport.go
@@ -1,0 +1,66 @@
+package tinfoil
+
+import (
+	"net/http"
+
+	"github.com/tinfoilsh/tinfoil-go/verifier/client"
+)
+
+// VerifiedTransport is an attested sealing transport to a verified enclave:
+// pinned TLS or EHBP, re-verifying attestation automatically when the enclave
+// rotates its keys. Unlike the client returned by NewClientWithOptions it
+// carries no OpenAI client, no cache-secret layer, and no origin binding, so
+// consumers that forward their own requests (for example a local proxy) can
+// compose their own stack around it. Wrap it with NewHostBoundTransport to
+// refuse requests to any other origin.
+type VerifiedTransport struct {
+	enclave   string
+	repo      string
+	transport http.RoundTripper
+}
+
+// NewVerifiedTransport verifies an enclave and returns its sealing transport.
+// By default it selects a router automatically, verifies against the default
+// config repository, and uses the EHBP transport. It honors WithEnclave,
+// WithRepo, WithTransport, WithBaseURL, and WithAttestationBundleURL; options
+// that only configure the OpenAI client or the cache-secret layer have no
+// effect here.
+func NewVerifiedTransport(opts ...ClientOption) (*VerifiedTransport, error) {
+	cfg, err := newClientConfig(opts)
+	if err != nil {
+		return nil, err
+	}
+	secureClient, err := newSecureClientFromConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return newVerifiedTransport(secureClient, cfg.transport, cfg.baseURL)
+}
+
+func newVerifiedTransport(secureClient *client.SecureClient, mode TransportMode, baseURL string) (*VerifiedTransport, error) {
+	httpClient, err := sealingHTTPClient(secureClient, mode, baseURL)
+	if err != nil {
+		return nil, err
+	}
+	return &VerifiedTransport{
+		enclave:   secureClient.Enclave(),
+		repo:      secureClient.Repo(),
+		transport: httpClient.Transport,
+	}, nil
+}
+
+// Enclave returns the verified enclave host requests are sealed to.
+func (t *VerifiedTransport) Enclave() string {
+	return t.enclave
+}
+
+// Repo returns the config repository the enclave was verified against.
+func (t *VerifiedTransport) Repo() string {
+	return t.repo
+}
+
+// RoundTrip sends the request over the sealed connection to the verified
+// enclave.
+func (t *VerifiedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t.transport.RoundTrip(req)
+}

--- a/verified_transport.go
+++ b/verified_transport.go
@@ -9,10 +9,8 @@ import (
 // VerifiedTransport is an attested sealing transport to a verified enclave:
 // pinned TLS or EHBP, re-verifying attestation automatically when the enclave
 // rotates its keys. Unlike the client returned by NewClientWithOptions it
-// carries no OpenAI client, no cache-secret layer, and no origin binding, so
-// consumers that forward their own requests (for example a local proxy) can
-// compose their own stack around it. Wrap it with NewHostBoundTransport to
-// refuse requests to any other origin.
+// carries no OpenAI client or cache-secret layer. It is bound to the verified
+// enclave and, when configured, the base URL's origin.
 type VerifiedTransport struct {
 	enclave   string
 	repo      string
@@ -42,10 +40,14 @@ func newVerifiedTransport(secureClient *client.SecureClient, mode TransportMode,
 	if err != nil {
 		return nil, err
 	}
+	transport, err := NewHostBoundTransport(secureClient.Enclave(), baseURL, httpClient.Transport)
+	if err != nil {
+		return nil, err
+	}
 	return &VerifiedTransport{
 		enclave:   secureClient.Enclave(),
 		repo:      secureClient.Repo(),
-		transport: httpClient.Transport,
+		transport: transport,
 	}, nil
 }
 

--- a/verified_transport_test.go
+++ b/verified_transport_test.go
@@ -53,6 +53,11 @@ func TestNewHostBoundTransportRejectsInvalidBaseURL(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestNewHostBoundTransportRejectsNilTransport(t *testing.T) {
+	_, err := NewHostBoundTransport("enclave.example.com", "", nil)
+	require.EqualError(t, err, "transport is required")
+}
+
 func TestNewVerifiedTransportRejectsInvalidConfig(t *testing.T) {
 	t.Run("invalid base URL", func(t *testing.T) {
 		_, err := NewVerifiedTransport(WithBaseURL("/v1"))
@@ -66,8 +71,8 @@ func TestNewVerifiedTransportRejectsInvalidConfig(t *testing.T) {
 }
 
 // TestNewVerifiedTransport performs real router selection and attestation,
-// mirroring TestNewClient, and pins that the returned transport is the bare
-// sealing transport with no cache-secret or origin-binding layers.
+// mirroring TestNewClient, and pins that the returned transport has an origin
+// guard directly around the bare sealing transport, with no cache-secret layer.
 func TestNewVerifiedTransport(t *testing.T) {
 	t.Setenv(UserCacheSecretEnv, "must-not-appear-in-the-stack")
 
@@ -75,6 +80,8 @@ func TestNewVerifiedTransport(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, vt.Enclave())
 	require.NotEmpty(t, vt.Repo())
-	_, ok := vt.transport.(*ehbpReVerifyingTransport)
-	require.True(t, ok, "expected the bare EHBP sealing transport, got %T", vt.transport)
+	guarded, ok := vt.transport.(*hostBoundRoundTripper)
+	require.True(t, ok, "expected an origin guard, got %T", vt.transport)
+	_, ok = guarded.transport.(*ehbpReVerifyingTransport)
+	require.True(t, ok, "expected the bare EHBP sealing transport under the guard, got %T", guarded.transport)
 }

--- a/verified_transport_test.go
+++ b/verified_transport_test.go
@@ -24,9 +24,9 @@ func (s *stubRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	}, nil
 }
 
-func TestNewHostBoundTransportBindsOrigins(t *testing.T) {
+func TestHostBoundTransportBindsOrigins(t *testing.T) {
 	stub := &stubRoundTripper{}
-	guarded, err := NewHostBoundTransport("enclave.example.com", "http://localhost:8080", stub)
+	guarded, err := newHostBoundTransport("enclave.example.com", "http://localhost:8080", stub)
 	require.NoError(t, err)
 
 	do := func(url string) error {
@@ -48,13 +48,13 @@ func TestNewHostBoundTransportBindsOrigins(t *testing.T) {
 	require.Nil(t, stub.req, "the wrapped transport must not see the refused request")
 }
 
-func TestNewHostBoundTransportRejectsInvalidBaseURL(t *testing.T) {
-	_, err := NewHostBoundTransport("enclave.example.com", "ftp://proxy.example", &stubRoundTripper{})
+func TestHostBoundTransportRejectsInvalidBaseURL(t *testing.T) {
+	_, err := newHostBoundTransport("enclave.example.com", "ftp://proxy.example", &stubRoundTripper{})
 	require.Error(t, err)
 }
 
-func TestNewHostBoundTransportRejectsNilTransport(t *testing.T) {
-	_, err := NewHostBoundTransport("enclave.example.com", "", nil)
+func TestHostBoundTransportRejectsNilTransport(t *testing.T) {
+	_, err := newHostBoundTransport("enclave.example.com", "", nil)
 	require.EqualError(t, err, "transport is required")
 }
 

--- a/verified_transport_test.go
+++ b/verified_transport_test.go
@@ -1,0 +1,80 @@
+package tinfoil
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stubRoundTripper records the last request and returns an empty 200.
+type stubRoundTripper struct {
+	req *http.Request
+}
+
+func (s *stubRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.req = req
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Body:       io.NopCloser(strings.NewReader("{}")),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestNewHostBoundTransportBindsOrigins(t *testing.T) {
+	stub := &stubRoundTripper{}
+	guarded, err := NewHostBoundTransport("enclave.example.com", "http://localhost:8080", stub)
+	require.NoError(t, err)
+
+	do := func(url string) error {
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		require.NoError(t, err)
+		resp, err := guarded.RoundTrip(req)
+		if resp != nil {
+			resp.Body.Close()
+		}
+		return err
+	}
+
+	require.NoError(t, do("https://enclave.example.com/v1/models"))
+	require.NoError(t, do("http://localhost:8080/v1/models"))
+
+	stub.req = nil
+	err = do("https://attacker.example.com/v1/models")
+	require.Error(t, err, "a foreign origin must be refused")
+	require.Nil(t, stub.req, "the wrapped transport must not see the refused request")
+}
+
+func TestNewHostBoundTransportRejectsInvalidBaseURL(t *testing.T) {
+	_, err := NewHostBoundTransport("enclave.example.com", "ftp://proxy.example", &stubRoundTripper{})
+	require.Error(t, err)
+}
+
+func TestNewVerifiedTransportRejectsInvalidConfig(t *testing.T) {
+	t.Run("invalid base URL", func(t *testing.T) {
+		_, err := NewVerifiedTransport(WithBaseURL("/v1"))
+		require.Error(t, err)
+	})
+
+	t.Run("unknown transport mode", func(t *testing.T) {
+		_, err := NewVerifiedTransport(WithEnclave("enclave.example.com"), WithTransport("bogus"))
+		require.Error(t, err)
+	})
+}
+
+// TestNewVerifiedTransport performs real router selection and attestation,
+// mirroring TestNewClient, and pins that the returned transport is the bare
+// sealing transport with no cache-secret or origin-binding layers.
+func TestNewVerifiedTransport(t *testing.T) {
+	t.Setenv(UserCacheSecretEnv, "must-not-appear-in-the-stack")
+
+	vt, err := NewVerifiedTransport()
+	require.NoError(t, err)
+	require.NotEmpty(t, vt.Enclave())
+	require.NotEmpty(t, vt.Repo())
+	_, ok := vt.transport.(*ehbpReVerifyingTransport)
+	require.True(t, ok, "expected the bare EHBP sealing transport, got %T", vt.transport)
+}

--- a/verifier/client/client.go
+++ b/verifier/client/client.go
@@ -6,7 +6,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
+	"strings"
+	"sync"
 
 	"github.com/tinfoilsh/tinfoil-go/verifier/attestation"
 	"github.com/tinfoilsh/tinfoil-go/verifier/github"
@@ -36,6 +40,8 @@ type GroundTruth struct {
 }
 
 type SecureClient struct {
+	mu sync.RWMutex
+
 	enclave, repo string
 
 	// When set, Verify fetches a pre-assembled attestation bundle from
@@ -116,11 +122,15 @@ func NewDefaultClient() (*SecureClient, error) {
 
 // Enclave returns the enclave URL
 func (s *SecureClient) Enclave() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.enclave
 }
 
 // Repo returns the repository URL
 func (s *SecureClient) Repo() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.repo
 }
 
@@ -128,16 +138,22 @@ func (s *SecureClient) Repo() string {
 // pre-assembled attestation bundle from {url}/attestation instead of attesting
 // the enclave directly. Pass an empty string to restore direct attestation.
 func (s *SecureClient) SetAttestationBundleURL(url string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.attestationBundleURL = url
 }
 
 // GroundTruth returns the last verified enclave state
 func (s *SecureClient) GroundTruth() *GroundTruth {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.groundTruth
 }
 
 // GroundTruthJSON returns the ground truth as a JSON string
 func (s *SecureClient) GroundTruthJSON() (string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	encoded, err := json.Marshal(s.groundTruth)
 	if err != nil {
 		return "", err
@@ -158,6 +174,12 @@ func (s *SecureClient) getSigstoreClient() (*sigstore.Client, error) {
 
 // Verify fetches the latest verification information from GitHub and Sigstore and stores the ground truth results in the client
 func (s *SecureClient) Verify() (*GroundTruth, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.verify()
+}
+
+func (s *SecureClient) verify() (*GroundTruth, error) {
 	// When an attestation bundle URL is configured, attest from the bundle so
 	// the enclave does not need to be reached directly (proxy-friendly).
 	if s.attestationBundleURL != "" {
@@ -181,7 +203,7 @@ func (s *SecureClient) Verify() (*GroundTruth, error) {
 		if err != nil {
 			return nil, fmt.Errorf("fetchBundle: failed to fetch attestation bundle: %v", err)
 		}
-		return s.VerifyFromBundle(bundle)
+		return s.verifyFromBundle(bundle)
 	}
 
 	var codeMeasurement = s.codeMeasurement
@@ -272,6 +294,12 @@ func (s *SecureClient) Verify() (*GroundTruth, error) {
 
 // VerifyFromBundle verifies using a pre-fetched attestation bundle (single-request verification)
 func (s *SecureClient) VerifyFromBundle(bundle *attestation.Bundle) (*GroundTruth, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.verifyFromBundle(bundle)
+}
+
+func (s *SecureClient) verifyFromBundle(bundle *attestation.Bundle) (*GroundTruth, error) {
 	sigstoreClient, err := s.getSigstoreClient()
 	if err != nil {
 		return nil, fmt.Errorf("verifyCode: failed to create sigstore client: %v", err)
@@ -319,10 +347,15 @@ func (s *SecureClient) VerifyFromBundle(bundle *attestation.Bundle) (*GroundTrut
 	if err != nil {
 		return nil, fmt.Errorf("verifyCertificate: %v", err)
 	}
+	if s.enclave != "" && !sameEnclaveHost(s.enclave, bundle.Domain) {
+		return nil, fmt.Errorf("attestation bundle changed enclave host from %q to %q", s.enclave, bundle.Domain)
+	}
 
-	s.enclave = bundle.Domain
+	if s.enclave == "" {
+		s.enclave = bundle.Domain
+	}
 	s.groundTruth = &GroundTruth{
-		EnclaveHost:        bundle.Domain,
+		EnclaveHost:        s.enclave,
 		TLSPublicKey:       enclaveVerification.TLSPublicKeyFP,
 		HPKEPublicKey:      enclaveVerification.HPKEPublicKey,
 		Digest:             bundle.Digest,
@@ -334,10 +367,34 @@ func (s *SecureClient) VerifyFromBundle(bundle *attestation.Bundle) (*GroundTrut
 	return s.groundTruth, nil
 }
 
+func sameEnclaveHost(left, right string) bool {
+	leftHost, leftPort, leftOK := normalizeEnclaveHost(left)
+	rightHost, rightPort, rightOK := normalizeEnclaveHost(right)
+	return leftOK && rightOK && leftHost == rightHost && leftPort == rightPort
+}
+
+func normalizeEnclaveHost(raw string) (string, string, bool) {
+	parsed, err := url.Parse("https://" + raw)
+	if err != nil || parsed.Hostname() == "" || parsed.User != nil || parsed.Path != "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", "", false
+	}
+	host := strings.TrimSuffix(strings.ToLower(parsed.Hostname()), ".")
+	if net.ParseIP(host) == nil && strings.Contains(host, ":") {
+		return "", "", false
+	}
+	port := parsed.Port()
+	if port == "" {
+		port = "443"
+	}
+	return host, port, true
+}
+
 // HTTPClient returns an HTTP client that only accepts TLS connections to the verified enclave
 func (s *SecureClient) HTTPClient() (*http.Client, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.groundTruth == nil {
-		_, err := s.Verify()
+		_, err := s.verify()
 		if err != nil {
 			return nil, fmt.Errorf("failed to verify enclave: %v", err)
 		}
@@ -357,7 +414,7 @@ func (s *SecureClient) makeRequest(req *http.Request) (*Response, error) {
 	// If URL doesn't start with anything, assume it's a relative path and set the base URL
 	if req.URL.Host == "" {
 		req.URL.Scheme = "https"
-		req.URL.Host = s.enclave
+		req.URL.Host = s.Enclave()
 	}
 
 	// Request headers may carry the API key, so never send them over a plaintext

--- a/verifier/client/client.go
+++ b/verifier/client/client.go
@@ -379,7 +379,9 @@ func normalizeEnclaveHost(raw string) (string, string, bool) {
 		return "", "", false
 	}
 	host := strings.TrimSuffix(strings.ToLower(parsed.Hostname()), ".")
-	if net.ParseIP(host) == nil && strings.Contains(host, ":") {
+	if ip := net.ParseIP(host); ip != nil {
+		host = ip.String()
+	} else if strings.Contains(host, ":") {
 		return "", "", false
 	}
 	port := parsed.Port()

--- a/verifier/client/client_test.go
+++ b/verifier/client/client_test.go
@@ -2,8 +2,11 @@ package client
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -109,6 +112,60 @@ func TestVerifyRejectsPinnedMeasurementWithBundle(t *testing.T) {
 	_, err := client.Verify()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot combine")
+}
+
+func TestVerifyFromBundleRejectsEnclaveChange(t *testing.T) {
+	bundle, err := attestation.FetchBundle()
+	assert.NoError(t, err)
+
+	client := NewSecureClient("other.example.com", defaultRouterRepo)
+	groundTruth, err := client.VerifyFromBundle(bundle)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "changed enclave host")
+	assert.Nil(t, groundTruth)
+	assert.Equal(t, "other.example.com", client.Enclave())
+	assert.Nil(t, client.GroundTruth())
+}
+
+func TestSameEnclaveHost(t *testing.T) {
+	tests := []struct {
+		left  string
+		right string
+		same  bool
+	}{
+		{"router.example.com", "ROUTER.EXAMPLE.COM", true},
+		{"router.example.com.", "router.example.com", true},
+		{"router.example.com:443", "router.example.com", true},
+		{"router.example.com:8443", "router.example.com", false},
+		{"router.example.com", "other.example.com", false},
+	}
+	for _, test := range tests {
+		assert.Equal(t, test.same, sameEnclaveHost(test.left, test.right), "%s, %s", test.left, test.right)
+	}
+}
+
+func TestSecureClientSerializesVerificationState(t *testing.T) {
+	bundleServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer bundleServer.Close()
+
+	client := NewSecureClient("enclave.example.com", defaultRouterRepo)
+	client.SetAttestationBundleURL(bundleServer.URL)
+
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_, _ = client.Verify()
+		}()
+		go func() {
+			defer wg.Done()
+			client.SetAttestationBundleURL(bundleServer.URL)
+		}()
+	}
+	wg.Wait()
 }
 
 func TestVerifyFromBundleJSON(t *testing.T) {

--- a/verifier/client/client_test.go
+++ b/verifier/client/client_test.go
@@ -2,8 +2,6 @@ package client
 
 import (
 	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"strings"
 	"sync"
@@ -138,6 +136,9 @@ func TestSameEnclaveHost(t *testing.T) {
 		{"router.example.com:443", "router.example.com", true},
 		{"router.example.com:8443", "router.example.com", false},
 		{"router.example.com", "other.example.com", false},
+		{"[2001:0db8:0:0:0:0:0:1]", "[2001:db8::1]", true},
+		{"[2001:db8::1]:443", "[2001:0db8::1]", true},
+		{"[2001:db8::1]:8443", "[2001:db8::1]", false},
 	}
 	for _, test := range tests {
 		assert.Equal(t, test.same, sameEnclaveHost(test.left, test.right), "%s, %s", test.left, test.right)
@@ -145,13 +146,10 @@ func TestSameEnclaveHost(t *testing.T) {
 }
 
 func TestSecureClientSerializesVerificationState(t *testing.T) {
-	bundleServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`{}`))
-	}))
-	defer bundleServer.Close()
+	const bundleURL = "https://%"
 
 	client := NewSecureClient("enclave.example.com", defaultRouterRepo)
-	client.SetAttestationBundleURL(bundleServer.URL)
+	client.SetAttestationBundleURL(bundleURL)
 
 	var wg sync.WaitGroup
 	for range 32 {
@@ -162,7 +160,7 @@ func TestSecureClientSerializesVerificationState(t *testing.T) {
 		}()
 		go func() {
 			defer wg.Done()
-			client.SetAttestationBundleURL(bundleServer.URL)
+			client.SetAttestationBundleURL(bundleURL)
 		}()
 	}
 	wg.Wait()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a composable, verified transport (`VerifiedTransport`) and an origin guard so you can build custom HTTP stacks around a sealed, attested connection. Also exports prompt‑cache helpers, refactors client setup to separate sealing from higher layers, and hardens re‑verification, redirect handling, and client identity (including IPv6 host canonicalization).

- **New Features**
  - `VerifiedTransport`: bare sealing transport (EHBP or pinned TLS) with auto re‑attestation; no OpenAI client, no cache‑secret; bound to the verified enclave and optional `baseURL`.
  - Origin guard (`newHostBoundTransport`): only allows the verified enclave’s HTTPS origin and optional `baseURL`; rejects invalid `baseURL` and nil transports.
  - Exported cache helpers: `UserCacheSecretField`, `UserCacheSecretEnv`, `DefaultUserCacheSecret`, `UserCacheSecretPathEligible`, `InjectUserCacheSecret`.
  - Client setup refactor: split option parsing and secure‑client construction (`newClientConfig`, `newSecureClientFromConfig`); added `sealingHTTPClient` and `secureClientForRepo` so the sealing transport can be composed independently.

- **Bug Fixes**
  - TLS re‑verification preserves the configured attestation bundle/pinning and runs once across concurrent failures; request bodies are replayed correctly (`newTLSReVerifyingTransport`).
  - EHBP transport no longer follows redirects, preventing body leaks to foreign origins; added `noBodyReplayTransport` to clear `GetBody` after encryption so plaintext isn’t replayed during recovery.
  - Verified client identity and configuration are preserved: verification state is serialized; enclave host comparison is canonicalized (incl. IPv6) and bundles that change it are rejected; normalized host matching and accessors prevent identity drift.

<sup>Written for commit 988b6ecc43ac966034eabb3ddf811bee34aec5b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-go/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

