### PR TITLE
sev: enforce PLATFORM_INFO.TSME_EN (require, not just permit)

### DIFF
--- a/verifier/attestation/sev.go
+++ b/verifier/attestation/sev.go
@@ -148,6 +148,9 @@ func verifySevReportWithEndorsements(attestationDoc string, isCompressed bool, v
 	if err := validate.SnpAttestation(attestation, valOpts); err != nil {
 		return nil, "", err
 	}
+	if err := enforceRequiredPlatformInfo(report, valOpts.PlatformInfo); err != nil {
+		return nil, "", err
+	}
 
 	return report, policyName, nil
 }
@@ -207,8 +210,38 @@ func verifySevReport(attestationDoc string, isCompressed bool, vcekDER []byte) (
 	if err := validate.SnpAttestation(attestation, valOpts); err != nil {
 		return nil, err
 	}
+	if err := enforceRequiredPlatformInfo(attestation.GetReport(), valOpts.PlatformInfo); err != nil {
+		return nil, err
+	}
 
 	return attestation.GetReport(), nil
+}
+
+// enforceRequiredPlatformInfo asserts that PLATFORM_INFO feature bits which
+// go-sev-guest validates with allowlist ("unauthorized ... enabled") rather than
+// require semantics are actually present when the policy requires them.
+//
+// As of go-sev-guest v0.15.0, validate.validatePlatformInfo applies allowlist/max
+// semantics uniformly to PLATFORM_INFO features (reject only if a feature is
+// reported but not allowed). That is correct for SMT — where an
+// enabled-but-not-allowed feature is the hazard — but wrong for TSME, which the
+// SPEC requires (reject if required but not reported, §3.7.2 #10). Under
+// allowlist semantics, Options.PlatformInfo.TSMEEnabled=true only permits TSME;
+// it never rejects a report with TSME OFF, so an unencrypted-memory platform
+// passes SnpAttestation. Tinfoil requires TSME (matching tinfoil-python/-rs/-js),
+// so assert it explicitly here.
+func enforceRequiredPlatformInfo(report *sevsnp.Report, required *abi.SnpPlatformInfo) error {
+	if required == nil {
+		return nil
+	}
+	info, err := abi.ParseSnpPlatformInfo(report.GetPlatformInfo())
+	if err != nil {
+		return fmt.Errorf("could not parse SNP PLATFORM_INFO: %w", err)
+	}
+	if required.TSMEEnabled && !info.TSMEEnabled {
+		return fmt.Errorf("platform policy violation: TSME (transparent SME) required but not enabled")
+	}
+	return nil
 }
 
 func verifySevAttestationV2(attestationDoc string) (*Verification, error) {

--- a/verifier/attestation/sev_platform_info_test.go
+++ b/verifier/attestation/sev_platform_info_test.go
@@ -1,0 +1,39 @@
+package attestation
+
+import (
+	"testing"
+
+	"github.com/google/go-sev-guest/abi"
+	"github.com/google/go-sev-guest/proto/sevsnp"
+)
+
+// TestEnforceRequiredPlatformInfoTSME guards the SPEC §3.7 TSME requirement.
+// go-sev-guest validates TSME with allowlist semantics (it only rejects a report
+// that HAS TSME when the policy disallows it), so a TSME-off report passes
+// validate.SnpAttestation even with Options.PlatformInfo.TSMEEnabled=true.
+// enforceRequiredPlatformInfo closes that gap; this test pins the behavior so it
+// stays consistent with tinfoil-python/-rs/-js.
+func TestEnforceRequiredPlatformInfoTSME(t *testing.T) {
+	const (
+		smtBit  = uint64(1 << 0)
+		tsmeBit = uint64(1 << 1)
+	)
+	required := &abi.SnpPlatformInfo{TSMEEnabled: true}
+
+	// TSME off -> rejected.
+	off := &sevsnp.Report{PlatformInfo: smtBit}
+	if err := enforceRequiredPlatformInfo(off, required); err == nil {
+		t.Fatal("expected a TSME-off report to be rejected when TSME is required")
+	}
+
+	// TSME on -> accepted.
+	on := &sevsnp.Report{PlatformInfo: smtBit | tsmeBit}
+	if err := enforceRequiredPlatformInfo(on, required); err != nil {
+		t.Fatalf("expected a TSME-on report to pass, got: %v", err)
+	}
+
+	// No policy -> no-op.
+	if err := enforceRequiredPlatformInfo(off, nil); err != nil {
+		t.Fatalf("expected nil required policy to be a no-op, got: %v", err)
+	}
+}


### PR DESCRIPTION
The SEV verifier set Options.PlatformInfo.TSMEEnabled=true but go-sev-guest's validate.validatePlatformInfo (v0.15.0) checks TSME with allowlist semantics — it rejects a report that HAS TSME when the policy disallows it, but never rejects a report with TSME OFF. So a report with transparent SME disabled passed verification, diverging from tinfoil-python (validate_sev.py), tinfoil-rs (validation.rs) and tinfoil-js (validation.ts), which all require TSME.

Add enforceRequiredPlatformInfo() and call it after validate.SnpAttestation on both the fixed-policy and endorsement paths, asserting TSME is present when the policy requires it. Surfaced by cross-SDK conformance fixture attestation-sev/264-platform-info-tsme-not-set.

Parity with the other SDKs, which all *require* TSME:
- tinfoil-python — [validate_sev.py#L275-L276](https://github.com/tinfoilsh/tinfoil-python/blob/78123c2faf86430af17dfed605201a888de7f626/src/tinfoil/attestation/validate_sev.py#L275-L276)
- tinfoil-rs — [validation.rs#L164-L166](https://github.com/tinfoilsh/tinfoil-rs/blob/cc6574402dfa37f926727a036045186e63fb13de/src/verifier/attestation/sev/validation.rs#L164-L166)
- tinfoil-js — [validation.ts#L391-L392](https://github.com/tinfoilsh/tinfoil-js/blob/f27c6d3a68921fd874b36b4acdc87f670370f140/packages/verifier/src/sev/validation.ts#L391-L392)

