### PR TITLE
sev: reject mem_aes256_xts guest policy when not allowed

### DIFF
--- a/verifier/attestation/sev.go
+++ b/verifier/attestation/sev.go
@@ -148,6 +148,9 @@ func verifySevReportWithEndorsements(attestationDoc string, isCompressed bool, v
 	if err := validate.SnpAttestation(attestation, valOpts); err != nil {
 		return nil, "", err
 	}
+	if err := enforceGuestPolicyAllowlist(report, valOpts.GuestPolicy); err != nil {
+		return nil, "", err
+	}
 
 	return report, policyName, nil
 }
@@ -207,8 +210,33 @@ func verifySevReport(attestationDoc string, isCompressed bool, vcekDER []byte) (
 	if err := validate.SnpAttestation(attestation, valOpts); err != nil {
 		return nil, err
 	}
+	if err := enforceGuestPolicyAllowlist(attestation.GetReport(), valOpts.GuestPolicy); err != nil {
+		return nil, err
+	}
 
 	return attestation.GetReport(), nil
+}
+
+// enforceGuestPolicyAllowlist covers guest-policy bits that go-sev-guest's
+// validate.validatePolicy checks with require ("required but not set") rather
+// than the allowlist ("reported but not allowed") semantics the SPEC mandates.
+//
+// As of go-sev-guest v0.15.0 this affects MEM_AES256_XTS: validatePolicy uses
+// `required.MemAES256XTS && !policy.MemAES256XTS`, so a report that ENABLES
+// AES-256-XTS memory encryption is never rejected, even when the expected policy
+// does not allow it. SPEC §3.7.2 #1 requires rejecting a report that enables
+// mem_aes256_xts when not allowed (the §3.7.1 default does not allow it),
+// matching tinfoil-python/-rs/-js. (CXL, by contrast, go-sev-guest already
+// checks with allowlist semantics.)
+func enforceGuestPolicyAllowlist(report *sevsnp.Report, allowed abi.SnpPolicy) error {
+	policy, err := abi.ParseSnpPolicy(report.GetPolicy())
+	if err != nil {
+		return fmt.Errorf("could not parse SNP guest policy: %w", err)
+	}
+	if policy.MemAES256XTS && !allowed.MemAES256XTS {
+		return fmt.Errorf("guest policy violation: mem_aes256_xts (AES-256-XTS memory encryption) enabled but not allowed")
+	}
+	return nil
 }
 
 func verifySevAttestationV2(attestationDoc string) (*Verification, error) {

--- a/verifier/attestation/sev_guest_policy_test.go
+++ b/verifier/attestation/sev_guest_policy_test.go
@@ -1,0 +1,38 @@
+package attestation
+
+import (
+	"testing"
+
+	"github.com/google/go-sev-guest/abi"
+	"github.com/google/go-sev-guest/proto/sevsnp"
+)
+
+// TestEnforceGuestPolicyAllowlistMemAES256XTS guards the SPEC §3.7.2 #1
+// allowlist requirement for mem_aes256_xts. go-sev-guest validates that bit with
+// require semantics (`required && !policy`), so a report that ENABLES AES-256-XTS
+// passes validate.SnpAttestation even when the policy doesn't allow it.
+// enforceGuestPolicyAllowlist closes that gap; this test pins the behavior so it
+// stays consistent with tinfoil-python/-rs/-js.
+func TestEnforceGuestPolicyAllowlistMemAES256XTS(t *testing.T) {
+	const (
+		mboBit          = uint64(1 << 17) // reserved, MUST be 1
+		memAES256XTSBit = uint64(1 << 22)
+	)
+
+	// mem_aes256_xts enabled, not allowed -> rejected.
+	on := &sevsnp.Report{Policy: mboBit | memAES256XTSBit}
+	if err := enforceGuestPolicyAllowlist(on, abi.SnpPolicy{}); err == nil {
+		t.Fatal("expected a mem_aes256_xts-enabled report to be rejected when not allowed")
+	}
+
+	// mem_aes256_xts enabled, explicitly allowed -> accepted.
+	if err := enforceGuestPolicyAllowlist(on, abi.SnpPolicy{MemAES256XTS: true}); err != nil {
+		t.Fatalf("expected a mem_aes256_xts-enabled report to pass when allowed, got: %v", err)
+	}
+
+	// mem_aes256_xts off -> accepted.
+	off := &sevsnp.Report{Policy: mboBit}
+	if err := enforceGuestPolicyAllowlist(off, abi.SnpPolicy{}); err != nil {
+		t.Fatalf("expected a mem_aes256_xts-off report to pass, got: %v", err)
+	}
+}


### PR DESCRIPTION
The SEV verifier accepted an attestation whose guest policy enables mem_aes256_xts (AES-256-XTS memory encryption) even when the policy doesn't allow it, diverging from tinfoil-python/-rs/-js which reject it.

Root cause: go-sev-guest v0.15.0's validate.validatePolicy checks mem_aes256_xts with require semantics (`required.MemAES256XTS && !policy.MemAES256XTS`) instead of the allowlist semantics the SPEC mandates. SPEC §3.7.2 #1 requires rejecting a report that ENABLES mem_aes256_xts when not allowed, and the §3.7.1 default does not allow it. (go-sev-guest already checks CXL with correct allowlist semantics; mem_aes256_xts is the one guest-policy bit with the wrong direction.)

Add enforceGuestPolicyAllowlist() and call it after validate.SnpAttestation on both the fixed-policy and endorsement paths. Surfaced by conformance fixture attestation-sev/606-guest-policy-mem-aes256-xts (go accepted; py/rs/js rejected).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject SEV attestations that enable AES-256-XTS memory encryption (`mem_aes256_xts`) when the guest policy doesn’t allow it. Aligns verification with the SNP spec and other tinfoil verifiers.

- **Bug Fixes**
  - Added `enforceGuestPolicyAllowlist()` and invoked it after `validate.SnpAttestation` on both endorsement and fixed-policy paths.
  - Now rejects reports with `MemAES256XTS` set when not allowed (SPEC §3.7.2; default in §3.7.1 disallows).
  - Added `TestEnforceGuestPolicyAllowlistMemAES256XTS` to pin behavior and match conformance fixture `attestation-sev/606-guest-policy-mem-aes256-xts`.

<sup>Written for commit 74bb17d5df975f50f4b2fe2c2058556fe3f0fa82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-go/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

