### PR TITLE
sev: permit SEV-TIO in platform-info policy

### DIFF
--- a/verifier/attestation/sev.go
+++ b/verifier/attestation/sev.go
@@ -193,6 +193,13 @@ func verifySevReport(attestationDoc string, isCompressed bool, vcekDER []byte) (
 			RAPLDisabled:                false,
 			CiphertextHidingDRAMEnabled: false,
 			AliasCheckComplete:          false,
+			// Permit SEV-TIO. go-sev-guest validates TIO with allowlist
+			// semantics (reject if reported but not allowed), but SPEC §3.7.2 #10
+			// treats tio_enabled as require-semantics, so a TIO-enabled platform
+			// must be accepted when TIO isn't specifically required. Marking it
+			// allowed here makes go accept tio-on (matching tinfoil-python/-rs/-js);
+			// tio-off is unaffected. See conformance fixture 275.
+			TIOEnabled: true,
 		},
 		RequireAuthorKey: false,
 		VMPL:             nil,


### PR DESCRIPTION
go-sev-guest v0.15.0 already parses the TIO bit (PLATFORM_INFO bit 7) but validates it with allowlist semantics (`reportInfo.TIOEnabled && !required.TIOEnabled` -> "unauthorized feature SEV-TIO enabled"). Since the verifier's valOpts didn't set TIOEnabled, a report from a TIO-enabled platform was rejected.

SPEC §3.7.2 #10 treats tio_enabled with require-semantics (reject only if required but not reported), so a TIO-enabled platform must be accepted when TIO isn't specifically required — which is what tinfoil-python/-rs/-js do. Mark TIO allowed in the fixed-policy valOpts so go accepts tio-on (tio-off is unaffected).

Surfaced by conformance fixture attestation-sev/275-platform-info-tio-enabled (go rejected; py/rs/js accepted). Note: the endorsement path (verifier/policy) has no tio_enabled field in the artifact SNPPlatform, so TIO-enabled machines verified via that flow would still be rejected — tracked separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Permit SEV‑TIO in platform‑info validation so TIO‑enabled platforms are accepted when TIO isn’t required. Aligns with SNP spec §3.7.2 and fixes conformance case 275.

- **Bug Fixes**
  - Set `TIOEnabled: true` in SEV validation options to satisfy `go-sev-guest` allowlist semantics and accept TIO‑on reports when not required.
  - Endorsement path still lacks `tio_enabled` in `SNPPlatform`; TIO‑enabled machines via that flow remain rejected (tracked separately).

<sup>Written for commit 0c27744fed5361dcadef141a00207c59f49f5f9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-go/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

