### PR TITLE
Expose verification provenance documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ if err != nil {
 // see https://pkg.go.dev/github.com/openai/openai-go/v3 for API documentation
 ```
 
+## Verification document
+
+The client retains the result used by its active secure transport:
+
+```go
+document := client.VerificationDocument()
+fmt.Println(document.ConfigRepo, document.ReleaseTag, document.ReleaseDigest)
+fmt.Println(document.Verifier.Name, document.Verifier.Version)
+fmt.Println(document.VerifiedAt)
+```
+
+`VerifiedAt` is recorded from the local clock after successful verification or
+re-verification. It is not an attested timestamp or evidence freshness
+guarantee.
+
 ## Advanced Functionality
 
 ```go

--- a/ehbp_transport.go
+++ b/ehbp_transport.go
@@ -245,6 +245,7 @@ func tlsPinnedHTTPClient(secureClient *client.SecureClient) (*http.Client, error
 	httpClient.Transport = &reVerifyingTransport{
 		secureClient: secureClient,
 		transport:    httpClient.Transport,
+		document:     secureClient.VerificationDocument(),
 	}
 	return httpClient, nil
 }
@@ -411,6 +412,7 @@ func buildEHBPTransport(hpkePublicKeyHex string) (http.RoundTripper, error) {
 type ehbpReVerifyingTransport struct {
 	mu         sync.RWMutex
 	transport  http.RoundTripper
+	document   *client.VerificationDocument
 	generation uint64
 
 	// reverifyMu serializes re-verification. Re-verification mutates shared
@@ -421,12 +423,17 @@ type ehbpReVerifyingTransport struct {
 
 	// reverify re-runs attestation and returns an EHBP transport built from the
 	// freshly attested HPKE key.
-	reverify func() (http.RoundTripper, error)
+	reverify              func() (http.RoundTripper, error)
+	build                 func(string) (http.RoundTripper, error)
+	documentAfterReverify func() *client.VerificationDocument
 }
 
 func newEHBPReVerifyingTransport(secureClient *client.SecureClient, inner http.RoundTripper, build func(hpkePublicKeyHex string) (http.RoundTripper, error)) *ehbpReVerifyingTransport {
 	return &ehbpReVerifyingTransport{
-		transport: inner,
+		transport:             inner,
+		document:              secureClient.VerificationDocument(),
+		build:                 build,
+		documentAfterReverify: secureClient.VerificationDocument,
 		reverify: func() (http.RoundTripper, error) {
 			groundTruth, err := secureClient.Verify()
 			if err != nil {
@@ -489,11 +496,44 @@ func (t *ehbpReVerifyingTransport) reverifyOnce(seenGeneration uint64) (http.Rou
 
 	t.mu.Lock()
 	t.transport = newTransport
+	if t.documentAfterReverify != nil {
+		t.document = t.documentAfterReverify()
+	}
 	t.generation++
 	t.mu.Unlock()
 
 	log.Info("HPKE key rotation detected, re-verified attestation successfully")
 	return newTransport, nil
+}
+
+func (t *ehbpReVerifyingTransport) replace(transport http.RoundTripper, document *client.VerificationDocument) {
+	t.mu.Lock()
+	t.transport = transport
+	t.document = document
+	t.generation++
+	t.mu.Unlock()
+}
+
+func (t *ehbpReVerifyingTransport) verificationDocument() *client.VerificationDocument {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.document.Clone()
+}
+
+func (t *ehbpReVerifyingTransport) verifyAndReplace(secureClient *client.SecureClient) (*client.GroundTruth, error) {
+	t.reverifyMu.Lock()
+	defer t.reverifyMu.Unlock()
+
+	groundTruth, err := secureClient.Verify()
+	if err != nil {
+		return nil, err
+	}
+	newTransport, err := t.build(groundTruth.HPKEPublicKey)
+	if err != nil {
+		return nil, err
+	}
+	t.replace(newTransport, secureClient.VerificationDocument())
+	return groundTruth, nil
 }
 
 // resetRequestBody returns a request whose body can be sent again. EHBP

--- a/ehbp_transport.go
+++ b/ehbp_transport.go
@@ -143,30 +143,30 @@ func NewClientWithOptions(opts ...ClientOption) (*Client, error) {
 		resolveUserCacheSecret(cfg.userCacheSecret, cfg.userCacheSecretSet), cfg.openaiOpts...)
 }
 
-// secureHTTPClient builds an *http.Client for the requested transport mode.
-//
-// The returned client is bound to the verified enclave (and the configured
-// proxy, if any). EHBP does not encrypt request headers end-to-end; TLS encrypts
-// them in transit, but sending them to another origin would disclose them to
-// that endpoint. Requests to any other origin are therefore refused.
-type securedHTTPClient struct {
-	client        *http.Client
-	tlsTransport  *reVerifyingTransport
-	ehbpTransport *ehbpReVerifyingTransport
+type verifiedTransport interface {
+	verifyAndReplace() (*client.GroundTruth, error)
+	verificationDocument() *client.VerificationDocument
 }
 
+type securedHTTPClient struct {
+	client    *http.Client
+	transport verifiedTransport
+}
+
+// secureHTTPClient builds an HTTP client and its verification-state owner for
+// the requested transport mode. The HTTP client is bound to the verified
+// enclave and configured proxy, if any.
 func secureHTTPClient(secureClient *client.SecureClient, mode TransportMode, baseURL, userCacheSecret string) (*securedHTTPClient, error) {
 	var (
 		httpClient    *http.Client
-		tlsTransport  *reVerifyingTransport
-		ehbpTransport *ehbpReVerifyingTransport
+		verifiedState verifiedTransport
 		err           error
 	)
 	switch mode {
 	case TransportTLS:
-		httpClient, tlsTransport, err = tlsPinnedHTTPClient(secureClient)
+		httpClient, verifiedState, err = tlsPinnedHTTPClient(secureClient)
 	case TransportEHBP, "":
-		httpClient, ehbpTransport, err = ehbpHTTPClient(secureClient, baseURL)
+		httpClient, verifiedState, err = ehbpHTTPClient(secureClient, baseURL)
 	default:
 		return nil, fmt.Errorf("unknown transport mode: %q", mode)
 	}
@@ -200,9 +200,8 @@ func secureHTTPClient(secureClient *client.SecureClient, mode TransportMode, bas
 		transport:      transport,
 	}
 	return &securedHTTPClient{
-		client:        httpClient,
-		tlsTransport:  tlsTransport,
-		ehbpTransport: ehbpTransport,
+		client:    httpClient,
+		transport: verifiedState,
 	}, nil
 }
 
@@ -422,10 +421,11 @@ func buildEHBPTransport(hpkePublicKeyHex string) (http.RoundTripper, error) {
 // attestation when the enclave rotates its HPKE key, mirroring the certificate
 // rotation handling of the TLS transport.
 type ehbpReVerifyingTransport struct {
-	mu         sync.RWMutex
-	transport  http.RoundTripper
-	document   *client.VerificationDocument
-	generation uint64
+	secureClient *client.SecureClient
+	mu           sync.RWMutex
+	transport    http.RoundTripper
+	document     *client.VerificationDocument
+	generation   uint64
 
 	// reverifyMu serializes re-verification. Re-verification mutates shared
 	// attestation state on the SecureClient, which is not safe for concurrent
@@ -442,6 +442,7 @@ type ehbpReVerifyingTransport struct {
 
 func newEHBPReVerifyingTransport(secureClient *client.SecureClient, inner http.RoundTripper, build func(hpkePublicKeyHex string) (http.RoundTripper, error)) *ehbpReVerifyingTransport {
 	return &ehbpReVerifyingTransport{
+		secureClient:          secureClient,
 		transport:             inner,
 		document:              secureClient.VerificationDocument(),
 		build:                 build,
@@ -532,11 +533,11 @@ func (t *ehbpReVerifyingTransport) verificationDocument() *client.VerificationDo
 	return t.document.Clone()
 }
 
-func (t *ehbpReVerifyingTransport) verifyAndReplace(secureClient *client.SecureClient) (*client.GroundTruth, error) {
+func (t *ehbpReVerifyingTransport) verifyAndReplace() (*client.GroundTruth, error) {
 	t.reverifyMu.Lock()
 	defer t.reverifyMu.Unlock()
 
-	groundTruth, err := secureClient.Verify()
+	groundTruth, err := t.secureClient.Verify()
 	if err != nil {
 		return nil, err
 	}
@@ -544,7 +545,7 @@ func (t *ehbpReVerifyingTransport) verifyAndReplace(secureClient *client.SecureC
 	if err != nil {
 		return nil, err
 	}
-	t.replace(newTransport, secureClient.VerificationDocument())
+	t.replace(newTransport, t.secureClient.VerificationDocument())
 	return groundTruth, nil
 }
 

--- a/ehbp_transport.go
+++ b/ehbp_transport.go
@@ -149,16 +149,24 @@ func NewClientWithOptions(opts ...ClientOption) (*Client, error) {
 // proxy, if any). EHBP does not encrypt request headers end-to-end; TLS encrypts
 // them in transit, but sending them to another origin would disclose them to
 // that endpoint. Requests to any other origin are therefore refused.
-func secureHTTPClient(secureClient *client.SecureClient, mode TransportMode, baseURL, userCacheSecret string) (*http.Client, error) {
+type securedHTTPClient struct {
+	client        *http.Client
+	tlsTransport  *reVerifyingTransport
+	ehbpTransport *ehbpReVerifyingTransport
+}
+
+func secureHTTPClient(secureClient *client.SecureClient, mode TransportMode, baseURL, userCacheSecret string) (*securedHTTPClient, error) {
 	var (
-		httpClient *http.Client
-		err        error
+		httpClient    *http.Client
+		tlsTransport  *reVerifyingTransport
+		ehbpTransport *ehbpReVerifyingTransport
+		err           error
 	)
 	switch mode {
 	case TransportTLS:
-		httpClient, err = tlsPinnedHTTPClient(secureClient)
+		httpClient, tlsTransport, err = tlsPinnedHTTPClient(secureClient)
 	case TransportEHBP, "":
-		httpClient, err = ehbpHTTPClient(secureClient, baseURL)
+		httpClient, ehbpTransport, err = ehbpHTTPClient(secureClient, baseURL)
 	default:
 		return nil, fmt.Errorf("unknown transport mode: %q", mode)
 	}
@@ -191,7 +199,11 @@ func secureHTTPClient(secureClient *client.SecureClient, mode TransportMode, bas
 		enclave:        secureClient.Enclave(),
 		transport:      transport,
 	}
-	return httpClient, nil
+	return &securedHTTPClient{
+		client:        httpClient,
+		tlsTransport:  tlsTransport,
+		ehbpTransport: ehbpTransport,
+	}, nil
 }
 
 // allowedOrigins returns the set of origins a secured request may target: the
@@ -235,19 +247,20 @@ func (t *hostBoundRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 
 // tlsPinnedHTTPClient returns the enclave-pinned HTTP client that re-verifies
 // attestation when the server's TLS certificate rotates.
-func tlsPinnedHTTPClient(secureClient *client.SecureClient) (*http.Client, error) {
+func tlsPinnedHTTPClient(secureClient *client.SecureClient) (*http.Client, *reVerifyingTransport, error) {
 	httpClient, err := secureClient.HTTPClient()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
+		return nil, nil, fmt.Errorf("failed to create HTTP client: %w", err)
 	}
 
 	// Wrap with re-verifying transport to handle certificate rotation
-	httpClient.Transport = &reVerifyingTransport{
+	transport := &reVerifyingTransport{
 		secureClient: secureClient,
 		transport:    httpClient.Transport,
 		document:     secureClient.VerificationDocument(),
 	}
-	return httpClient, nil
+	httpClient.Transport = transport
+	return httpClient, transport, nil
 }
 
 // ehbpHTTPClient returns an HTTP client whose request bodies are encrypted to
@@ -255,13 +268,13 @@ func tlsPinnedHTTPClient(secureClient *client.SecureClient) (*http.Client, error
 // the server rotates its HPKE key. When baseURL routes requests through a proxy
 // whose origin differs from the enclave's, the client adds the
 // X-Tinfoil-Enclave-Url header so the proxy can forward to the verified enclave.
-func ehbpHTTPClient(secureClient *client.SecureClient, baseURL string) (*http.Client, error) {
+func ehbpHTTPClient(secureClient *client.SecureClient, baseURL string) (*http.Client, *ehbpReVerifyingTransport, error) {
 	groundTruth := secureClient.GroundTruth()
 	if groundTruth == nil {
 		var err error
 		groundTruth, err = secureClient.Verify()
 		if err != nil {
-			return nil, fmt.Errorf("failed to verify enclave: %w", err)
+			return nil, nil, fmt.Errorf("failed to verify enclave: %w", err)
 		}
 	}
 
@@ -287,12 +300,11 @@ func ehbpHTTPClient(secureClient *client.SecureClient, baseURL string) (*http.Cl
 
 	inner, err := buildTransport(groundTruth.HPKEPublicKey)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return &http.Client{
-		Transport: newEHBPReVerifyingTransport(secureClient, inner, buildTransport),
-	}, nil
+	transport := newEHBPReVerifyingTransport(secureClient, inner, buildTransport)
+	return &http.Client{Transport: transport}, transport, nil
 }
 
 // enclaveURLHeaderValue returns the X-Tinfoil-Enclave-Url header value and

--- a/tinfoil_client.go
+++ b/tinfoil_client.go
@@ -20,11 +20,15 @@ type reVerifyingTransport struct {
 	secureClient *client.SecureClient
 	mu           sync.RWMutex
 	transport    http.RoundTripper
+	document     *client.VerificationDocument
+	generation   uint64
+	reverifyMu   sync.Mutex
 }
 
 func (t *reVerifyingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	t.mu.RLock()
 	transport := t.transport
+	generation := t.generation
 	t.mu.RUnlock()
 
 	resp, err := transport.RoundTrip(req)
@@ -32,11 +36,26 @@ func (t *reVerifyingTransport) RoundTrip(req *http.Request) (*http.Response, err
 		return resp, err
 	}
 
-	// Certificate error detected, reinitialize secure client to re-verify attestation
-	newSecureClient := client.NewSecureClient(t.secureClient.Enclave(), t.secureClient.Repo())
-	newHTTPClient, clientErr := newSecureClient.HTTPClient()
+	t.reverifyMu.Lock()
+	defer t.reverifyMu.Unlock()
+
+	t.mu.RLock()
+	if t.generation != generation {
+		transport = t.transport
+		t.mu.RUnlock()
+		return transport.RoundTrip(req)
+	}
+	t.mu.RUnlock()
+
+	// Certificate error detected, re-verify the existing client so its
+	// verification document and configured verification mode stay current.
+	_, clientErr := t.secureClient.Verify()
 	if clientErr != nil {
 		// Re-verification failed, connection is genuinely malicious
+		return nil, err
+	}
+	newHTTPClient, clientErr := t.secureClient.HTTPClient()
+	if clientErr != nil {
 		return nil, err
 	}
 
@@ -44,8 +63,9 @@ func (t *reVerifyingTransport) RoundTrip(req *http.Request) (*http.Response, err
 	log.Info("Certificate rotation detected, re-verified attestation successfully")
 
 	t.mu.Lock()
-	t.secureClient = newSecureClient
 	t.transport = newHTTPClient.Transport
+	t.document = t.secureClient.VerificationDocument()
+	t.generation++
 	t.mu.Unlock()
 
 	return newHTTPClient.Transport.RoundTrip(req)
@@ -72,6 +92,8 @@ type Client struct {
 	httpClient    *http.Client
 	enclave, repo string
 	transport     TransportMode
+	tlsTransport  *reVerifyingTransport
+	ehbpTransport *ehbpReVerifyingTransport
 }
 
 // NewClientWithParams creates a new secure OpenAI client with explicit enclave and repo parameters
@@ -110,13 +132,17 @@ func createClientFromSecureClient(secureClient *client.SecureClient, mode Transp
 	)
 
 	openaiClient := openai.NewClient(allOpts...)
+	tlsTransport := findReVerifyingTransport(httpClient.Transport)
+	ehbpTransport := findEHBPReVerifyingTransport(httpClient.Transport)
 	return &Client{
-		Client:       &openaiClient,
-		secureClient: secureClient,
-		httpClient:   httpClient,
-		enclave:      secureClient.Enclave(),
-		repo:         secureClient.Repo(),
-		transport:    mode,
+		Client:        &openaiClient,
+		secureClient:  secureClient,
+		httpClient:    httpClient,
+		enclave:       secureClient.Enclave(),
+		repo:          secureClient.Repo(),
+		transport:     mode,
+		tlsTransport:  tlsTransport,
+		ehbpTransport: ehbpTransport,
 	}, nil
 }
 
@@ -135,7 +161,80 @@ func (c *Client) Transport() TransportMode {
 
 // Verify re-verifies the enclave attestation and returns the ground truth
 func (c *Client) Verify() (*client.GroundTruth, error) {
+	if c.tlsTransport != nil {
+		return c.tlsTransport.verifyAndReplace()
+	}
+	if c.ehbpTransport != nil {
+		return c.ehbpTransport.verifyAndReplace(c.secureClient)
+	}
 	return c.secureClient.Verify()
+}
+
+// VerificationDocument returns the result used by the active secure transport.
+func (c *Client) VerificationDocument() *client.VerificationDocument {
+	if c.tlsTransport != nil {
+		return c.tlsTransport.verificationDocument()
+	}
+	if c.ehbpTransport != nil {
+		return c.ehbpTransport.verificationDocument()
+	}
+	return c.secureClient.VerificationDocument()
+}
+
+func findEHBPReVerifyingTransport(transport http.RoundTripper) *ehbpReVerifyingTransport {
+	switch typed := transport.(type) {
+	case *hostBoundRoundTripper:
+		return findEHBPReVerifyingTransport(typed.transport)
+	case *userCacheSecretTransport:
+		return findEHBPReVerifyingTransport(typed.transport)
+	case *ehbpReVerifyingTransport:
+		return typed
+	default:
+		return nil
+	}
+}
+
+func (t *reVerifyingTransport) replace(transport http.RoundTripper, document *client.VerificationDocument) {
+	t.mu.Lock()
+	t.transport = transport
+	t.document = document
+	t.generation++
+	t.mu.Unlock()
+}
+
+func (t *reVerifyingTransport) verificationDocument() *client.VerificationDocument {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.document.Clone()
+}
+
+func (t *reVerifyingTransport) verifyAndReplace() (*client.GroundTruth, error) {
+	t.reverifyMu.Lock()
+	defer t.reverifyMu.Unlock()
+
+	groundTruth, err := t.secureClient.Verify()
+	if err != nil {
+		return nil, err
+	}
+	httpClient, err := t.secureClient.HTTPClient()
+	if err != nil {
+		return nil, err
+	}
+	t.replace(httpClient.Transport, t.secureClient.VerificationDocument())
+	return groundTruth, nil
+}
+
+func findReVerifyingTransport(transport http.RoundTripper) *reVerifyingTransport {
+	switch typed := transport.(type) {
+	case *hostBoundRoundTripper:
+		return findReVerifyingTransport(typed.transport)
+	case *userCacheSecretTransport:
+		return findReVerifyingTransport(typed.transport)
+	case *reVerifyingTransport:
+		return typed
+	default:
+		return nil
+	}
 }
 
 // HTTPClient returns the underlying HTTP client used to reach the enclave. It

--- a/tinfoil_client.go
+++ b/tinfoil_client.go
@@ -113,10 +113,11 @@ func NewClient(openaiOpts ...option.RequestOption) (*Client, error) {
 
 // createClientFromSecureClient is a helper function to create a Client from a SecureClient
 func createClientFromSecureClient(secureClient *client.SecureClient, mode TransportMode, baseURL, userCacheSecret string, openaiOpts ...option.RequestOption) (*Client, error) {
-	httpClient, err := secureHTTPClient(secureClient, mode, baseURL, userCacheSecret)
+	securedClient, err := secureHTTPClient(secureClient, mode, baseURL, userCacheSecret)
 	if err != nil {
 		return nil, err
 	}
+	httpClient := securedClient.client
 
 	// Route requests through the proxy base URL when set, otherwise straight to
 	// the verified enclave.
@@ -132,8 +133,6 @@ func createClientFromSecureClient(secureClient *client.SecureClient, mode Transp
 	)
 
 	openaiClient := openai.NewClient(allOpts...)
-	tlsTransport := findReVerifyingTransport(httpClient.Transport)
-	ehbpTransport := findEHBPReVerifyingTransport(httpClient.Transport)
 	return &Client{
 		Client:        &openaiClient,
 		secureClient:  secureClient,
@@ -141,8 +140,8 @@ func createClientFromSecureClient(secureClient *client.SecureClient, mode Transp
 		enclave:       secureClient.Enclave(),
 		repo:          secureClient.Repo(),
 		transport:     mode,
-		tlsTransport:  tlsTransport,
-		ehbpTransport: ehbpTransport,
+		tlsTransport:  securedClient.tlsTransport,
+		ehbpTransport: securedClient.ehbpTransport,
 	}, nil
 }
 
@@ -181,19 +180,6 @@ func (c *Client) VerificationDocument() *client.VerificationDocument {
 	return c.secureClient.VerificationDocument()
 }
 
-func findEHBPReVerifyingTransport(transport http.RoundTripper) *ehbpReVerifyingTransport {
-	switch typed := transport.(type) {
-	case *hostBoundRoundTripper:
-		return findEHBPReVerifyingTransport(typed.transport)
-	case *userCacheSecretTransport:
-		return findEHBPReVerifyingTransport(typed.transport)
-	case *ehbpReVerifyingTransport:
-		return typed
-	default:
-		return nil
-	}
-}
-
 func (t *reVerifyingTransport) replace(transport http.RoundTripper, document *client.VerificationDocument) {
 	t.mu.Lock()
 	t.transport = transport
@@ -222,19 +208,6 @@ func (t *reVerifyingTransport) verifyAndReplace() (*client.GroundTruth, error) {
 	}
 	t.replace(httpClient.Transport, t.secureClient.VerificationDocument())
 	return groundTruth, nil
-}
-
-func findReVerifyingTransport(transport http.RoundTripper) *reVerifyingTransport {
-	switch typed := transport.(type) {
-	case *hostBoundRoundTripper:
-		return findReVerifyingTransport(typed.transport)
-	case *userCacheSecretTransport:
-		return findReVerifyingTransport(typed.transport)
-	case *reVerifyingTransport:
-		return typed
-	default:
-		return nil
-	}
 }
 
 // HTTPClient returns the underlying HTTP client used to reach the enclave. It

--- a/tinfoil_client.go
+++ b/tinfoil_client.go
@@ -88,12 +88,11 @@ func isCertificateError(err error) bool {
 // Client wraps the OpenAI client to provide secure inference through Tinfoil
 type Client struct {
 	*openai.Client
-	secureClient  *client.SecureClient
-	httpClient    *http.Client
-	enclave, repo string
-	transport     TransportMode
-	tlsTransport  *reVerifyingTransport
-	ehbpTransport *ehbpReVerifyingTransport
+	secureClient      *client.SecureClient
+	httpClient        *http.Client
+	enclave, repo     string
+	transport         TransportMode
+	verifiedTransport verifiedTransport
 }
 
 // NewClientWithParams creates a new secure OpenAI client with explicit enclave and repo parameters
@@ -134,14 +133,13 @@ func createClientFromSecureClient(secureClient *client.SecureClient, mode Transp
 
 	openaiClient := openai.NewClient(allOpts...)
 	return &Client{
-		Client:        &openaiClient,
-		secureClient:  secureClient,
-		httpClient:    httpClient,
-		enclave:       secureClient.Enclave(),
-		repo:          secureClient.Repo(),
-		transport:     mode,
-		tlsTransport:  securedClient.tlsTransport,
-		ehbpTransport: securedClient.ehbpTransport,
+		Client:            &openaiClient,
+		secureClient:      secureClient,
+		httpClient:        httpClient,
+		enclave:           secureClient.Enclave(),
+		repo:              secureClient.Repo(),
+		transport:         mode,
+		verifiedTransport: securedClient.transport,
 	}, nil
 }
 
@@ -160,22 +158,16 @@ func (c *Client) Transport() TransportMode {
 
 // Verify re-verifies the enclave attestation and returns the ground truth
 func (c *Client) Verify() (*client.GroundTruth, error) {
-	if c.tlsTransport != nil {
-		return c.tlsTransport.verifyAndReplace()
-	}
-	if c.ehbpTransport != nil {
-		return c.ehbpTransport.verifyAndReplace(c.secureClient)
+	if c.verifiedTransport != nil {
+		return c.verifiedTransport.verifyAndReplace()
 	}
 	return c.secureClient.Verify()
 }
 
 // VerificationDocument returns the result used by the active secure transport.
 func (c *Client) VerificationDocument() *client.VerificationDocument {
-	if c.tlsTransport != nil {
-		return c.tlsTransport.verificationDocument()
-	}
-	if c.ehbpTransport != nil {
-		return c.ehbpTransport.verificationDocument()
+	if c.verifiedTransport != nil {
+		return c.verifiedTransport.verificationDocument()
 	}
 	return c.secureClient.VerificationDocument()
 }

--- a/verifier/attestation/attestation.go
+++ b/verifier/attestation/attestation.go
@@ -232,6 +232,7 @@ type Bundle struct {
 	Domain                   string          `json:"domain"`
 	EnclaveAttestationReport *Document       `json:"enclaveAttestationReport"`
 	Digest                   string          `json:"digest"`
+	ReleaseTag               string          `json:"releaseTag,omitempty"`
 	SigstoreBundle           json.RawMessage `json:"sigstoreBundle"`
 	VCEK                     string          `json:"vcek"`
 	EnclaveCert              string          `json:"enclaveCert"`

--- a/verifier/client/client.go
+++ b/verifier/client/client.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sync"
+	"time"
 
 	"github.com/tinfoilsh/tinfoil-go/verifier/attestation"
 	"github.com/tinfoilsh/tinfoil-go/verifier/github"
@@ -24,7 +26,9 @@ var embeddedTrustedRoot []byte
 
 // GroundTruth represents the "known good" state of the enclave
 type GroundTruth struct {
+	ConfigRepo          string                           `json:"config_repo,omitempty"`
 	EnclaveHost         string                           `json:"enclave_host,omitempty"`
+	ReleaseTag          string                           `json:"release_tag,omitempty"`
 	TLSPublicKey        string                           `json:"tls_public_key,omitempty"`
 	HPKEPublicKey       string                           `json:"hpke_public_key,omitempty"`
 	Digest              string                           `json:"digest"`
@@ -33,6 +37,8 @@ type GroundTruth struct {
 	HardwareMeasurement *attestation.HardwareMeasurement `json:"hardware_measurement,omitempty"`
 	CodeFingerprint     string                           `json:"code_fingerprint"`
 	EnclaveFingerprint  string                           `json:"enclave_fingerprint"`
+	Verifier            SoftwareIdentity                 `json:"verifier"`
+	VerifiedAt          string                           `json:"verified_at"`
 }
 
 type SecureClient struct {
@@ -48,15 +54,21 @@ type SecureClient struct {
 	codeMeasurement      *attestation.Measurement
 	hardwareMeasurements []*attestation.HardwareMeasurement
 
-	groundTruth    *GroundTruth
-	sigstoreClient *sigstore.Client
+	groundTruth          *GroundTruth
+	verificationDocument *VerificationDocument
+	stateMu              sync.RWMutex
+	verifyMu             sync.Mutex
+	sigstoreClient       *sigstore.Client
 }
 
 var (
 	defaultRouterRepo = "tinfoilsh/confidential-model-router"
 	defaultRouterURL  = "https://atc.tinfoil.sh/routers"
-	defaultClient     = NewSecureClient("inference.tinfoil.sh", defaultRouterRepo)
 )
+
+func newFallbackClient() *SecureClient {
+	return NewSecureClient("inference.tinfoil.sh", defaultRouterRepo)
+}
 
 func fetchRouters() ([]string, error) {
 	resp, _, err := util.Get(defaultRouterURL)
@@ -97,7 +109,7 @@ func NewDefaultClient() (*SecureClient, error) {
 	routers, err := fetchRouters()
 	if err != nil {
 		// If we can't get routers, fall back to inference.tinfoil.sh immediately
-		return defaultClient, nil
+		return newFallbackClient(), nil
 	}
 
 	// Try each router in sequence
@@ -111,7 +123,7 @@ func NewDefaultClient() (*SecureClient, error) {
 		}
 	}
 
-	return defaultClient, nil
+	return newFallbackClient(), nil
 }
 
 // Enclave returns the enclave URL
@@ -133,12 +145,30 @@ func (s *SecureClient) SetAttestationBundleURL(url string) {
 
 // GroundTruth returns the last verified enclave state
 func (s *SecureClient) GroundTruth() *GroundTruth {
-	return s.groundTruth
+	s.stateMu.RLock()
+	defer s.stateMu.RUnlock()
+	return cloneGroundTruth(s.groundTruth)
 }
 
 // GroundTruthJSON returns the ground truth as a JSON string
 func (s *SecureClient) GroundTruthJSON() (string, error) {
-	encoded, err := json.Marshal(s.groundTruth)
+	encoded, err := json.Marshal(s.GroundTruth())
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
+// VerificationDocument returns the last successful Verification Center-compatible result.
+func (s *SecureClient) VerificationDocument() *VerificationDocument {
+	s.stateMu.RLock()
+	defer s.stateMu.RUnlock()
+	return cloneVerificationDocument(s.verificationDocument)
+}
+
+// VerificationDocumentJSON returns the last successful verification document as JSON.
+func (s *SecureClient) VerificationDocumentJSON() (string, error) {
+	encoded, err := json.Marshal(s.VerificationDocument())
 	if err != nil {
 		return "", err
 	}
@@ -158,6 +188,9 @@ func (s *SecureClient) getSigstoreClient() (*sigstore.Client, error) {
 
 // Verify fetches the latest verification information from GitHub and Sigstore and stores the ground truth results in the client
 func (s *SecureClient) Verify() (*GroundTruth, error) {
+	s.verifyMu.Lock()
+	defer s.verifyMu.Unlock()
+
 	// When an attestation bundle URL is configured, attest from the bundle so
 	// the enclave does not need to be reached directly (proxy-friendly).
 	if s.attestationBundleURL != "" {
@@ -181,17 +214,19 @@ func (s *SecureClient) Verify() (*GroundTruth, error) {
 		if err != nil {
 			return nil, fmt.Errorf("fetchBundle: failed to fetch attestation bundle: %v", err)
 		}
-		return s.VerifyFromBundle(bundle)
+		return s.verifyFromBundle(bundle)
 	}
 
 	var codeMeasurement = s.codeMeasurement
 	var digest = pinnedNoDigest
+	var releaseTag string
 	if s.codeMeasurement == nil {
-		var err error
-		digest, err = github.FetchLatestDigest(s.repo)
+		release, err := github.FetchLatestRelease(s.repo)
 		if err != nil {
 			return nil, fmt.Errorf("fetchDigest: failed to fetch latest release: %v", err)
 		}
+		digest = release.Digest
+		releaseTag = release.Tag
 
 		sigstoreClient, err := s.getSigstoreClient()
 		if err != nil {
@@ -256,8 +291,10 @@ func (s *SecureClient) Verify() (*GroundTruth, error) {
 		return nil, fmt.Errorf("measurements: failed to compute enclave fingerprint: %v", err)
 	}
 
-	s.groundTruth = &GroundTruth{
+	groundTruth := &GroundTruth{
+		ConfigRepo:          s.repo,
 		EnclaveHost:         s.enclave,
+		ReleaseTag:          releaseTag,
 		TLSPublicKey:        enclaveVerification.TLSPublicKeyFP,
 		HPKEPublicKey:       enclaveVerification.HPKEPublicKey,
 		Digest:              digest,
@@ -266,12 +303,21 @@ func (s *SecureClient) Verify() (*GroundTruth, error) {
 		EnclaveMeasurement:  enclaveVerification.Measurement,
 		CodeFingerprint:     codeFingerprint,
 		EnclaveFingerprint:  enclaveFingerprint,
+		Verifier:            currentVerifierIdentity(),
+		VerifiedAt:          verificationTime().UTC().Format(time.RFC3339Nano),
 	}
-	return s.groundTruth, nil
+	s.setVerifiedState(groundTruth)
+	return groundTruth, nil
 }
 
 // VerifyFromBundle verifies using a pre-fetched attestation bundle (single-request verification)
 func (s *SecureClient) VerifyFromBundle(bundle *attestation.Bundle) (*GroundTruth, error) {
+	s.verifyMu.Lock()
+	defer s.verifyMu.Unlock()
+	return s.verifyFromBundle(bundle)
+}
+
+func (s *SecureClient) verifyFromBundle(bundle *attestation.Bundle) (*GroundTruth, error) {
 	sigstoreClient, err := s.getSigstoreClient()
 	if err != nil {
 		return nil, fmt.Errorf("verifyCode: failed to create sigstore client: %v", err)
@@ -321,7 +367,8 @@ func (s *SecureClient) VerifyFromBundle(bundle *attestation.Bundle) (*GroundTrut
 	}
 
 	s.enclave = bundle.Domain
-	s.groundTruth = &GroundTruth{
+	groundTruth := &GroundTruth{
+		ConfigRepo:         s.repo,
 		EnclaveHost:        bundle.Domain,
 		TLSPublicKey:       enclaveVerification.TLSPublicKeyFP,
 		HPKEPublicKey:      enclaveVerification.HPKEPublicKey,
@@ -330,21 +377,26 @@ func (s *SecureClient) VerifyFromBundle(bundle *attestation.Bundle) (*GroundTrut
 		EnclaveMeasurement: enclaveVerification.Measurement,
 		CodeFingerprint:    codeFingerprint,
 		EnclaveFingerprint: enclaveFingerprint,
+		Verifier:           currentVerifierIdentity(),
+		VerifiedAt:         verificationTime().UTC().Format(time.RFC3339Nano),
 	}
-	return s.groundTruth, nil
+	s.setVerifiedState(groundTruth)
+	return groundTruth, nil
 }
 
 // HTTPClient returns an HTTP client that only accepts TLS connections to the verified enclave
 func (s *SecureClient) HTTPClient() (*http.Client, error) {
-	if s.groundTruth == nil {
+	groundTruth := s.GroundTruth()
+	if groundTruth == nil {
 		_, err := s.Verify()
 		if err != nil {
 			return nil, fmt.Errorf("failed to verify enclave: %v", err)
 		}
+		groundTruth = s.GroundTruth()
 	}
 
 	return &http.Client{
-		Transport: &TLSBoundRoundTripper{ExpectedPublicKey: s.groundTruth.TLSPublicKey},
+		Transport: &TLSBoundRoundTripper{ExpectedPublicKey: groundTruth.TLSPublicKey},
 	}, nil
 }
 

--- a/verifier/client/client.go
+++ b/verifier/client/client.go
@@ -39,6 +39,7 @@ type GroundTruth struct {
 	EnclaveFingerprint  string                           `json:"enclave_fingerprint"`
 	Verifier            SoftwareIdentity                 `json:"verifier"`
 	VerifiedAt          string                           `json:"verified_at"`
+	DigestFetched       bool                             `json:"-"`
 }
 
 type SecureClient struct {
@@ -128,6 +129,8 @@ func NewDefaultClient() (*SecureClient, error) {
 
 // Enclave returns the enclave URL
 func (s *SecureClient) Enclave() string {
+	s.stateMu.RLock()
+	defer s.stateMu.RUnlock()
 	return s.enclave
 }
 
@@ -240,7 +243,7 @@ func (s *SecureClient) Verify() (*GroundTruth, error) {
 			return nil, fmt.Errorf("verifyCode: failed to fetch attestation bundle: %v", err)
 		}
 
-		codeMeasurement, err = sigstoreClient.VerifyAttestation(sigstoreBundle, s.repo, digest)
+		codeMeasurement, err = sigstoreClient.VerifyAttestationForRelease(sigstoreBundle, s.repo, releaseTag, digest)
 		if err != nil {
 			return nil, fmt.Errorf("verifyCode: failed to verify attested measurements: %v", err)
 		}
@@ -307,6 +310,7 @@ func (s *SecureClient) Verify() (*GroundTruth, error) {
 		EnclaveFingerprint:  enclaveFingerprint,
 		Verifier:            currentVerifierIdentity(),
 		VerifiedAt:          verificationTime().UTC().Format(time.RFC3339Nano),
+		DigestFetched:       s.codeMeasurement == nil,
 	}
 	s.setVerifiedState(groundTruth)
 	return groundTruth, nil
@@ -320,12 +324,23 @@ func (s *SecureClient) VerifyFromBundle(bundle *attestation.Bundle) (*GroundTrut
 }
 
 func (s *SecureClient) verifyFromBundle(bundle *attestation.Bundle) (*GroundTruth, error) {
+	if err := s.validateBundleDomain(bundle.Domain); err != nil {
+		return nil, err
+	}
+
 	sigstoreClient, err := s.getSigstoreClient()
 	if err != nil {
 		return nil, fmt.Errorf("verifyCode: failed to create sigstore client: %v", err)
 	}
 
-	codeMeasurement, err := sigstoreClient.VerifyAttestation(bundle.SigstoreBundle, s.repo, bundle.Digest)
+	var codeMeasurement *attestation.Measurement
+	if bundle.ReleaseTag != "" {
+		codeMeasurement, err = sigstoreClient.VerifyAttestationForRelease(
+			bundle.SigstoreBundle, s.repo, bundle.ReleaseTag, bundle.Digest,
+		)
+	} else {
+		codeMeasurement, err = sigstoreClient.VerifyAttestation(bundle.SigstoreBundle, s.repo, bundle.Digest)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("verifyCode: failed to verify attested measurements: %v", err)
 	}
@@ -368,10 +383,10 @@ func (s *SecureClient) verifyFromBundle(bundle *attestation.Bundle) (*GroundTrut
 		return nil, fmt.Errorf("verifyCertificate: %v", err)
 	}
 
-	s.enclave = bundle.Domain
 	groundTruth := &GroundTruth{
 		ConfigRepo:         s.repo,
 		EnclaveHost:        bundle.Domain,
+		ReleaseTag:         bundle.ReleaseTag,
 		TLSPublicKey:       enclaveVerification.TLSPublicKeyFP,
 		HPKEPublicKey:      enclaveVerification.HPKEPublicKey,
 		Digest:             bundle.Digest,
@@ -384,6 +399,13 @@ func (s *SecureClient) verifyFromBundle(bundle *attestation.Bundle) (*GroundTrut
 	}
 	s.setVerifiedState(groundTruth)
 	return groundTruth, nil
+}
+
+func (s *SecureClient) validateBundleDomain(domain string) error {
+	if groundTruth := s.GroundTruth(); groundTruth != nil && domain != groundTruth.EnclaveHost {
+		return fmt.Errorf("verifyBundle: domain %q does not match verified enclave %q", domain, groundTruth.EnclaveHost)
+	}
+	return nil
 }
 
 // HTTPClient returns an HTTP client that only accepts TLS connections to the verified enclave

--- a/verifier/client/client.go
+++ b/verifier/client/client.go
@@ -140,6 +140,8 @@ func (s *SecureClient) Repo() string {
 // pre-assembled attestation bundle from {url}/attestation instead of attesting
 // the enclave directly. Pass an empty string to restore direct attestation.
 func (s *SecureClient) SetAttestationBundleURL(url string) {
+	s.verifyMu.Lock()
+	defer s.verifyMu.Unlock()
 	s.attestationBundleURL = url
 }
 

--- a/verifier/client/client_test.go
+++ b/verifier/client/client_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tinfoilsh/tinfoil-go/verifier/attestation"
@@ -52,6 +53,39 @@ func TestClientGroundTruthJSON(t *testing.T) {
 	assert.Equal(t, gt, &gt2)
 }
 
+func TestVerificationDocumentJSON(t *testing.T) {
+	verifiedAt := time.Date(2026, time.August, 4, 12, 30, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	groundTruth := &GroundTruth{
+		ConfigRepo:         "tinfoilsh/confidential-model-router",
+		EnclaveHost:        "router.example",
+		ReleaseTag:         "v1.2.3",
+		TLSPublicKey:       "tls-fingerprint",
+		HPKEPublicKey:      "hpke-key",
+		Digest:             "release-digest",
+		CodeMeasurement:    &attestation.Measurement{Type: attestation.SevGuestV2, Registers: []string{"code"}},
+		EnclaveMeasurement: &attestation.Measurement{Type: attestation.SevGuestV2, Registers: []string{"enclave"}},
+		CodeFingerprint:    "code-fingerprint",
+		EnclaveFingerprint: "enclave-fingerprint",
+		Verifier:           SoftwareIdentity{Name: verifierName, Version: "v1.0.0"},
+		VerifiedAt:         verifiedAt,
+	}
+	client := &SecureClient{
+		groundTruth:          groundTruth,
+		verificationDocument: newVerificationDocument(groundTruth),
+	}
+
+	encoded, err := client.VerificationDocumentJSON()
+	assert.NoError(t, err)
+
+	var document VerificationDocument
+	assert.NoError(t, json.Unmarshal([]byte(encoded), &document))
+	assert.Equal(t, verificationDocumentSchemaVersion, document.SchemaVersion)
+	assert.Equal(t, "v1.2.3", document.ReleaseTag)
+	assert.Equal(t, verifiedAt, document.VerifiedAt)
+	assert.Equal(t, "tls-fingerprint", document.EnclaveMeasurement.TLSPublicKeyFingerprint)
+	assert.True(t, document.SecurityVerified)
+}
+
 func TestNewDefaultSecureClient(t *testing.T) {
 	client, err := NewDefaultClient()
 	assert.NoError(t, err)
@@ -72,6 +106,7 @@ func TestClientFetchRouters(t *testing.T) {
 }
 
 func TestClientDefaultClient(t *testing.T) {
+	defaultClient := newFallbackClient()
 	enclave := defaultClient.Enclave()
 	assert.NotEmpty(t, enclave)
 

--- a/verifier/client/client_test.go
+++ b/verifier/client/client_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"os"
+	"runtime/debug"
 	"strings"
 	"testing"
 	"time"
@@ -88,6 +89,66 @@ func TestVerificationDocumentJSON(t *testing.T) {
 	assert.Equal(t, verifiedAt, document.VerifiedAt)
 	assert.Equal(t, "tls-fingerprint", document.EnclaveMeasurement.TLSPublicKeyFingerprint)
 	assert.True(t, document.SecurityVerified)
+}
+
+func TestVerificationDocumentStepStates(t *testing.T) {
+	tests := []struct {
+		name        string
+		groundTruth *GroundTruth
+		fetchDigest string
+		verifyCode  string
+	}{
+		{name: "direct release", groundTruth: &GroundTruth{ReleaseTag: "v1.2.3", Digest: "digest", DigestFetched: true}, fetchDigest: "success", verifyCode: "success"},
+		{name: "caller supplied bundle", groundTruth: &GroundTruth{ReleaseTag: "v1.2.3", Digest: "digest"}, fetchDigest: "skipped", verifyCode: "success"},
+		{name: "pinned", groundTruth: &GroundTruth{Digest: pinnedNoDigest}, fetchDigest: "skipped", verifyCode: "skipped"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			document := newVerificationDocument(tt.groundTruth)
+			assert.Equal(t, tt.fetchDigest, document.Steps.FetchDigest.Status)
+			assert.Equal(t, tt.verifyCode, document.Steps.VerifyCode.Status)
+		})
+	}
+}
+
+func TestCurrentVerifierVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		info    *debug.BuildInfo
+		ok      bool
+		version string
+	}{
+		{name: "released main module", info: &debug.BuildInfo{Main: debug.Module{Path: verifierModulePath, Version: "v1.2.3"}}, ok: true, version: "1.2.3"},
+		{name: "released dependency", info: &debug.BuildInfo{Main: debug.Module{Path: "example.com/app"}, Deps: []*debug.Module{{Path: verifierModulePath, Version: "v2.3.4"}}}, ok: true, version: "2.3.4"},
+		{name: "local replacement", info: &debug.BuildInfo{Main: debug.Module{Path: "example.com/app"}, Deps: []*debug.Module{{Path: verifierModulePath, Version: "v1.2.3", Replace: &debug.Module{Path: "../tinfoil-go"}}}}, ok: true, version: "devel"},
+		{name: "development build", info: &debug.BuildInfo{Main: debug.Module{Path: verifierModulePath, Version: "(devel)"}}, ok: true, version: "devel"},
+		{name: "missing build info", ok: false, version: "unknown"},
+		{name: "module absent", info: &debug.BuildInfo{Main: debug.Module{Path: "example.com/app"}}, ok: true, version: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.version, verifierVersion(tt.info, tt.ok))
+		})
+	}
+}
+
+func TestVerifyFromBundleRejectsVerifiedDomainMismatch(t *testing.T) {
+	client := NewSecureClient("verified.example", defaultRouterRepo)
+	client.setVerifiedState(&GroundTruth{EnclaveHost: "verified.example"})
+
+	_, err := client.VerifyFromBundle(&attestation.Bundle{Domain: "other.example"})
+
+	assert.EqualError(t, err, `verifyBundle: domain "other.example" does not match verified enclave "verified.example"`)
+	assert.Equal(t, "verified.example", client.Enclave())
+	assert.Equal(t, "verified.example", client.GroundTruth().EnclaveHost)
+}
+
+func TestBundleDomainAllowsInitialDiscovery(t *testing.T) {
+	client := NewSecureClient("configured.example", defaultRouterRepo)
+
+	assert.NoError(t, client.validateBundleDomain("discovered.example"))
 }
 
 func TestNewDefaultSecureClient(t *testing.T) {

--- a/verifier/client/client_test.go
+++ b/verifier/client/client_test.go
@@ -80,7 +80,11 @@ func TestVerificationDocumentJSON(t *testing.T) {
 	var document VerificationDocument
 	assert.NoError(t, json.Unmarshal([]byte(encoded), &document))
 	assert.Equal(t, verificationDocumentSchemaVersion, document.SchemaVersion)
+	assert.Equal(t, "tinfoilsh/confidential-model-router", document.ConfigRepo)
 	assert.Equal(t, "v1.2.3", document.ReleaseTag)
+	assert.Equal(t, "release-digest", document.ReleaseDigest)
+	assert.Equal(t, verifierName, document.Verifier.Name)
+	assert.Equal(t, "v1.0.0", document.Verifier.Version)
 	assert.Equal(t, verifiedAt, document.VerifiedAt)
 	assert.Equal(t, "tls-fingerprint", document.EnclaveMeasurement.TLSPublicKeyFingerprint)
 	assert.True(t, document.SecurityVerified)

--- a/verifier/client/verification_document.go
+++ b/verifier/client/verification_document.go
@@ -1,0 +1,165 @@
+package client
+
+import (
+	"time"
+
+	"github.com/tinfoilsh/tinfoil-go/verifier/attestation"
+)
+
+const (
+	verificationDocumentSchemaVersion = 1
+	verifierName                      = "tinfoil-go"
+	// Version is the verifier package version reported in verification documents.
+	Version = "0.15.0"
+)
+
+var verificationTime = time.Now
+
+// SoftwareIdentity identifies software involved in verification.
+type SoftwareIdentity struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// VerificationStepState describes one verification step.
+type VerificationStepState struct {
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
+// VerificationSteps describes the checks represented by a verification document.
+type VerificationSteps struct {
+	FetchDigest         VerificationStepState `json:"fetchDigest"`
+	VerifyCode          VerificationStepState `json:"verifyCode"`
+	VerifyEnclave       VerificationStepState `json:"verifyEnclave"`
+	CompareMeasurements VerificationStepState `json:"compareMeasurements"`
+	VerifyCertificate   VerificationStepState `json:"verifyCertificate"`
+}
+
+// DocumentEnclaveMeasurement contains the observed measurement and attested keys.
+type DocumentEnclaveMeasurement struct {
+	Measurement             *attestation.Measurement `json:"measurement"`
+	TLSPublicKeyFingerprint string                   `json:"tlsPublicKeyFingerprint,omitempty"`
+	HPKEPublicKey           string                   `json:"hpkePublicKey,omitempty"`
+}
+
+// VerificationDocument is the Verification Center-compatible result of verification.
+type VerificationDocument struct {
+	SchemaVersion          int                              `json:"schemaVersion"`
+	ConfigRepo             string                           `json:"configRepo"`
+	EnclaveHost            string                           `json:"enclaveHost"`
+	ReleaseTag             string                           `json:"releaseTag,omitempty"`
+	ReleaseDigest          string                           `json:"releaseDigest"`
+	CodeMeasurement        *attestation.Measurement         `json:"codeMeasurement"`
+	EnclaveMeasurement     DocumentEnclaveMeasurement       `json:"enclaveMeasurement"`
+	TLSPublicKey           string                           `json:"tlsPublicKey"`
+	HPKEPublicKey          string                           `json:"hpkePublicKey"`
+	HardwareMeasurement    *attestation.HardwareMeasurement `json:"hardwareMeasurement,omitempty"`
+	CodeFingerprint        string                           `json:"codeFingerprint"`
+	EnclaveFingerprint     string                           `json:"enclaveFingerprint"`
+	SelectedRouterEndpoint string                           `json:"selectedRouterEndpoint"`
+	SecurityVerified       bool                             `json:"securityVerified"`
+	Verifier               SoftwareIdentity                 `json:"verifier"`
+	VerifiedAt             string                           `json:"verifiedAt,omitempty"`
+	Steps                  VerificationSteps                `json:"steps"`
+}
+
+func currentVerifierIdentity() SoftwareIdentity {
+	return SoftwareIdentity{Name: verifierName, Version: Version}
+}
+
+func successfulStep() VerificationStepState {
+	return VerificationStepState{Status: "success"}
+}
+
+func skippedStep() VerificationStepState {
+	return VerificationStepState{Status: "skipped"}
+}
+
+func newVerificationDocument(groundTruth *GroundTruth) *VerificationDocument {
+	fetchDigest := successfulStep()
+	verifyCode := successfulStep()
+	if groundTruth.Digest == pinnedNoDigest {
+		fetchDigest = skippedStep()
+		verifyCode = skippedStep()
+	}
+	return &VerificationDocument{
+		SchemaVersion:   verificationDocumentSchemaVersion,
+		ConfigRepo:      groundTruth.ConfigRepo,
+		EnclaveHost:     groundTruth.EnclaveHost,
+		ReleaseTag:      groundTruth.ReleaseTag,
+		ReleaseDigest:   groundTruth.Digest,
+		CodeMeasurement: groundTruth.CodeMeasurement,
+		EnclaveMeasurement: DocumentEnclaveMeasurement{
+			Measurement:             groundTruth.EnclaveMeasurement,
+			TLSPublicKeyFingerprint: groundTruth.TLSPublicKey,
+			HPKEPublicKey:           groundTruth.HPKEPublicKey,
+		},
+		TLSPublicKey:           groundTruth.TLSPublicKey,
+		HPKEPublicKey:          groundTruth.HPKEPublicKey,
+		HardwareMeasurement:    groundTruth.HardwareMeasurement,
+		CodeFingerprint:        groundTruth.CodeFingerprint,
+		EnclaveFingerprint:     groundTruth.EnclaveFingerprint,
+		SelectedRouterEndpoint: groundTruth.EnclaveHost,
+		SecurityVerified:       true,
+		Verifier:               groundTruth.Verifier,
+		VerifiedAt:             groundTruth.VerifiedAt,
+		Steps: VerificationSteps{
+			FetchDigest:         fetchDigest,
+			VerifyCode:          verifyCode,
+			VerifyEnclave:       successfulStep(),
+			CompareMeasurements: successfulStep(),
+			VerifyCertificate:   successfulStep(),
+		},
+	}
+}
+
+func (s *SecureClient) setVerifiedState(groundTruth *GroundTruth) {
+	clonedGroundTruth := cloneGroundTruth(groundTruth)
+	s.stateMu.Lock()
+	s.groundTruth = clonedGroundTruth
+	s.verificationDocument = newVerificationDocument(clonedGroundTruth)
+	s.stateMu.Unlock()
+}
+
+func cloneVerificationDocument(document *VerificationDocument) *VerificationDocument {
+	if document == nil {
+		return nil
+	}
+	cloned := *document
+	cloned.CodeMeasurement = cloneMeasurement(document.CodeMeasurement)
+	cloned.EnclaveMeasurement.Measurement = cloneMeasurement(document.EnclaveMeasurement.Measurement)
+	if document.HardwareMeasurement != nil {
+		hardware := *document.HardwareMeasurement
+		cloned.HardwareMeasurement = &hardware
+	}
+	return &cloned
+}
+
+// Clone returns a deep copy of the verification document.
+func (document *VerificationDocument) Clone() *VerificationDocument {
+	return cloneVerificationDocument(document)
+}
+
+func cloneMeasurement(measurement *attestation.Measurement) *attestation.Measurement {
+	if measurement == nil {
+		return nil
+	}
+	cloned := *measurement
+	cloned.Registers = append([]string(nil), measurement.Registers...)
+	return &cloned
+}
+
+func cloneGroundTruth(groundTruth *GroundTruth) *GroundTruth {
+	if groundTruth == nil {
+		return nil
+	}
+	cloned := *groundTruth
+	cloned.CodeMeasurement = cloneMeasurement(groundTruth.CodeMeasurement)
+	cloned.EnclaveMeasurement = cloneMeasurement(groundTruth.EnclaveMeasurement)
+	if groundTruth.HardwareMeasurement != nil {
+		hardware := *groundTruth.HardwareMeasurement
+		cloned.HardwareMeasurement = &hardware
+	}
+	return &cloned
+}

--- a/verifier/client/verification_document.go
+++ b/verifier/client/verification_document.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/tinfoilsh/tinfoil-go/verifier/attestation"
@@ -9,7 +11,8 @@ import (
 const (
 	verificationDocumentSchemaVersion = 1
 	verifierName                      = "tinfoil-go"
-	// Version is the verifier package version reported in verification documents.
+	verifierModulePath                = "github.com/tinfoilsh/tinfoil-go"
+	// Version is the Tinfoil Go SDK release version.
 	Version = "0.15.0"
 )
 
@@ -65,7 +68,37 @@ type VerificationDocument struct {
 }
 
 func currentVerifierIdentity() SoftwareIdentity {
-	return SoftwareIdentity{Name: verifierName, Version: Version}
+	return SoftwareIdentity{Name: verifierName, Version: currentVerifierVersion()}
+}
+
+func currentVerifierVersion() string {
+	return verifierVersion(debug.ReadBuildInfo())
+}
+
+func verifierVersion(info *debug.BuildInfo, ok bool) string {
+	if !ok {
+		return "unknown"
+	}
+	if info.Main.Path == verifierModulePath {
+		return buildModuleVersion(&info.Main)
+	}
+	for _, dependency := range info.Deps {
+		if dependency.Path == verifierModulePath {
+			return buildModuleVersion(dependency)
+		}
+	}
+	return "unknown"
+}
+
+func buildModuleVersion(module *debug.Module) string {
+	if module.Replace != nil {
+		module = module.Replace
+	}
+	version := strings.TrimPrefix(module.Version, "v")
+	if version == "" || version == "(devel)" {
+		return "devel"
+	}
+	return version
 }
 
 func successfulStep() VerificationStepState {
@@ -77,10 +110,12 @@ func skippedStep() VerificationStepState {
 }
 
 func newVerificationDocument(groundTruth *GroundTruth) *VerificationDocument {
-	fetchDigest := successfulStep()
+	fetchDigest := skippedStep()
 	verifyCode := successfulStep()
+	if groundTruth.DigestFetched {
+		fetchDigest = successfulStep()
+	}
 	if groundTruth.Digest == pinnedNoDigest {
-		fetchDigest = skippedStep()
 		verifyCode = skippedStep()
 	}
 	return &VerificationDocument{
@@ -117,6 +152,9 @@ func newVerificationDocument(groundTruth *GroundTruth) *VerificationDocument {
 func (s *SecureClient) setVerifiedState(groundTruth *GroundTruth) {
 	clonedGroundTruth := cloneGroundTruth(groundTruth)
 	s.stateMu.Lock()
+	if clonedGroundTruth.EnclaveHost != "" {
+		s.enclave = clonedGroundTruth.EnclaveHost
+	}
 	s.groundTruth = clonedGroundTruth
 	s.verificationDocument = newVerificationDocument(clonedGroundTruth)
 	s.stateMu.Unlock()

--- a/verifier/github/github.go
+++ b/verifier/github/github.go
@@ -50,11 +50,11 @@ func FetchDigest(repo, tag string) (string, error) {
 func FetchLatestRelease(repo string) (*Release, error) {
 	latestTag, err := FetchLatestTag(repo)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch latest tag: %v", err)
+		return nil, fmt.Errorf("failed to fetch latest tag: %w", err)
 	}
 	digest, err := FetchDigest(repo, latestTag)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch digest for %s@%s: %v", repo, latestTag, err)
+		return nil, fmt.Errorf("failed to fetch digest for %s@%s: %w", repo, latestTag, err)
 	}
 	return &Release{Tag: latestTag, Digest: digest}, nil
 }

--- a/verifier/github/github.go
+++ b/verifier/github/github.go
@@ -10,6 +10,12 @@ import (
 
 const githubProxy = "https://github-proxy.tinfoil.sh"
 
+// Release identifies the release artifact selected for verification.
+type Release struct {
+	Tag    string
+	Digest string
+}
+
 // FetchLatestTag fetches the latest tag for a repo
 func FetchLatestTag(repo string) (string, error) {
 	url := githubProxy + "/repos/" + repo + "/releases/latest"
@@ -40,17 +46,26 @@ func FetchDigest(repo, tag string) (string, error) {
 	return strings.TrimSpace(string(digest)), nil
 }
 
-// FetchLatestDigest gets the latest release, tag, and attestation digest of a repo
-func FetchLatestDigest(repo string) (string, error) {
+// FetchLatestRelease gets the latest release tag and attestation digest of a repo.
+func FetchLatestRelease(repo string) (*Release, error) {
 	latestTag, err := FetchLatestTag(repo)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch latest tag: %v", err)
+		return nil, fmt.Errorf("failed to fetch latest tag: %v", err)
 	}
 	digest, err := FetchDigest(repo, latestTag)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch digest for %s@%s: %v", repo, latestTag, err)
+		return nil, fmt.Errorf("failed to fetch digest for %s@%s: %v", repo, latestTag, err)
 	}
-	return digest, nil
+	return &Release{Tag: latestTag, Digest: digest}, nil
+}
+
+// FetchLatestDigest gets the attestation digest of the latest release of a repo.
+func FetchLatestDigest(repo string) (string, error) {
+	release, err := FetchLatestRelease(repo)
+	if err != nil {
+		return "", err
+	}
+	return release.Digest, nil
 }
 
 // FetchAttestationBundle fetches the sigstore bundle from a repo for a given repo and EIF hash

--- a/verifier/policy/artifact.go
+++ b/verifier/policy/artifact.go
@@ -46,8 +46,16 @@ type Artifact struct {
 
 // PlatformMeasurement is one TDX platform configuration's expected registers.
 type PlatformMeasurement struct {
-	MRTD  string `json:"mrtd"`
-	RTMR0 string `json:"rtmr0"`
+	MRTD  string        `json:"mrtd"`
+	RTMR0 string        `json:"rtmr0"`
+	Shape *MachineShape `json:"shape,omitempty"`
+}
+
+// MachineShape describes the VM resources bound to a platform measurement.
+type MachineShape struct {
+	CPUs     uint32 `json:"cpus"`
+	Disks    uint32 `json:"disks"`
+	MemoryMB uint32 `json:"memory_mb"`
 }
 
 // Policy is a named appraisal policy. Exactly one platform block is set,
@@ -60,15 +68,21 @@ type Policy struct {
 
 // SEVSNPPolicy is the standard SEV-SNP policy block.
 type SEVSNPPolicy struct {
-	MinimumBuild              uint8       `json:"minimum_build"`
-	MinimumAPIVersion         string      `json:"minimum_api_version"`
-	MinimumGuestSVN           uint32      `json:"minimum_guest_svn"`
-	MinimumTCB                TCB         `json:"minimum_tcb"`
-	MinimumLaunchTCB          TCB         `json:"minimum_launch_tcb"`
-	GuestPolicy               GuestPolicy `json:"guest_policy"`
-	PlatformInfo              SNPPlatform `json:"platform_info"`
-	PermitProvisionalFirmware bool        `json:"permit_provisional_firmware"`
-	VMPL                      *int        `json:"vmpl"`
+	FamilyID                       string      `json:"family_id"`
+	HostData                       string      `json:"host_data"`
+	ImageID                        string      `json:"image_id"`
+	MinimumABIVersion              string      `json:"minimum_abi_version"`
+	MinimumBuild                   uint8       `json:"minimum_build"`
+	MinimumAPIVersion              string      `json:"minimum_api_version"`
+	MinimumCurrentMitigationVector uint64      `json:"minimum_current_mitigation_vector"`
+	MinimumGuestSVN                uint32      `json:"minimum_guest_svn"`
+	MinimumLaunchMitigationVector  uint64      `json:"minimum_launch_mitigation_vector"`
+	MinimumTCB                     TCB         `json:"minimum_tcb"`
+	MinimumLaunchTCB               TCB         `json:"minimum_launch_tcb"`
+	GuestPolicy                    GuestPolicy `json:"guest_policy"`
+	PlatformInfo                   SNPPlatform `json:"platform_info"`
+	PermitProvisionalFirmware      bool        `json:"permit_provisional_firmware"`
+	VMPL                           *int        `json:"vmpl"`
 }
 
 // TCB holds AMD security patch levels. FmcSpl applies to family 1Ah (Turin)
@@ -91,6 +105,7 @@ type GuestPolicy struct {
 
 // SNPPlatform mirrors the SNP PLATFORM_INFO expectations.
 type SNPPlatform struct {
+	AliasCheckComplete   bool `json:"alias_check_complete"`
 	SMTEnabled           bool `json:"smt_enabled"`
 	TSMEEnabled          bool `json:"tsme_enabled"`
 	ECCEnabled           bool `json:"ecc_enabled"`
@@ -105,6 +120,7 @@ type TDXPolicy struct {
 	MinimumPCESVN                  uint16   `json:"minimum_pce_svn"`
 	MinimumTEETCBSVN               string   `json:"minimum_tee_tcb_svn"`
 	AcceptedMRSeams                []string `json:"accepted_mr_seams"`
+	MRSeam                         string   `json:"mr_seam"`
 	TDAttributes                   string   `json:"td_attributes"`
 	XFAM                           string   `json:"xfam"`
 	MRConfigIDZero                 bool     `json:"mr_config_id_zero"`
@@ -130,6 +146,16 @@ func ParseArtifact(data []byte) (*Artifact, error) {
 	}
 	if a.Format != ArtifactFormat {
 		return nil, fmt.Errorf("unsupported artifact format %q", a.Format)
+	}
+	for name, endorsementPolicy := range a.Policies {
+		if endorsementPolicy.TDX == nil || endorsementPolicy.TDX.MRSeam == "" {
+			continue
+		}
+		if len(endorsementPolicy.TDX.AcceptedMRSeams) != 0 {
+			return nil, fmt.Errorf("policy %q: mr_seam and accepted_mr_seams are mutually exclusive", name)
+		}
+		endorsementPolicy.TDX.AcceptedMRSeams = []string{endorsementPolicy.TDX.MRSeam}
+		a.Policies[name] = endorsementPolicy
 	}
 	if err := a.validate(); err != nil {
 		return nil, err

--- a/verifier/policy/translate.go
+++ b/verifier/policy/translate.go
@@ -31,25 +31,54 @@ func (p *SEVSNPPolicy) SEVOptions(productLine string) (*sevvalidate.Options, err
 	if p.MinimumTCB.FmcSpl != nil || p.MinimumLaunchTCB.FmcSpl != nil {
 		return nil, fmt.Errorf("fmc_spl is not valid for product line %s", productLine)
 	}
+	familyID, err := optionalHexField("family_id", p.FamilyID, 16)
+	if err != nil {
+		return nil, err
+	}
+	hostData, err := optionalHexField("host_data", p.HostData, 32)
+	if err != nil {
+		return nil, err
+	}
+	imageID, err := optionalHexField("image_id", p.ImageID, 16)
+	if err != nil {
+		return nil, err
+	}
+	var abiMajor, abiMinor uint8
+	if p.MinimumABIVersion != "" {
+		abiVersion, err := parseAPIVersion(p.MinimumABIVersion)
+		if err != nil {
+			return nil, fmt.Errorf("minimum ABI version: %w", err)
+		}
+		abiMajor = uint8(abiVersion >> 8)
+		abiMinor = uint8(abiVersion)
+	}
 
 	return &sevvalidate.Options{
 		GuestPolicy: sevabi.SnpPolicy{
+			ABIMajor:     abiMajor,
+			ABIMinor:     abiMinor,
 			Debug:        p.GuestPolicy.Debug,
 			SMT:          p.GuestPolicy.SMT,
 			MigrateMA:    p.GuestPolicy.MigrateMA,
 			SingleSocket: p.GuestPolicy.SingleSocket,
 		},
+		FamilyID:                  familyID,
+		HostData:                  hostData,
+		ImageID:                   imageID,
 		MinimumGuestSvn:           p.MinimumGuestSVN,
 		MinimumBuild:              p.MinimumBuild,
 		MinimumVersion:            version,
 		PermitProvisionalFirmware: p.PermitProvisionalFirmware,
 		PlatformInfo: &sevabi.SnpPlatformInfo{
+			AliasCheckComplete:          p.PlatformInfo.AliasCheckComplete,
 			SMTEnabled:                  p.PlatformInfo.SMTEnabled,
 			TSMEEnabled:                 p.PlatformInfo.TSMEEnabled,
 			ECCEnabled:                  p.PlatformInfo.ECCEnabled,
 			RAPLDisabled:                p.PlatformInfo.RAPLDisabled,
 			CiphertextHidingDRAMEnabled: p.PlatformInfo.CiphertextHidingDRAM,
 		},
+		MinimumCurrentMitigationVector: p.MinimumCurrentMitigationVector,
+		MinimumLaunchMitigationVector:  p.MinimumLaunchMitigationVector,
 		MinimumTCB: kds.TCBParts{
 			BlSpl:    p.MinimumTCB.BlSpl,
 			TeeSpl:   p.MinimumTCB.TeeSpl,
@@ -205,4 +234,11 @@ func hexField(name, value string, wantLen int) ([]byte, error) {
 		return nil, fmt.Errorf("%s must be %d bytes, got %d", name, wantLen, len(b))
 	}
 	return b, nil
+}
+
+func optionalHexField(name, value string, wantLen int) ([]byte, error) {
+	if value == "" {
+		return nil, nil
+	}
+	return hexField(name, value, wantLen)
 }

--- a/verifier/sigstore/sigstore.go
+++ b/verifier/sigstore/sigstore.go
@@ -23,14 +23,14 @@ const (
 
 	// platformEndorsementsRepo publishes the platform-endorsements artifact.
 	platformEndorsementsRepo = "tinfoilsh/platform-endorsements"
+)
 
-	// platformEndorsementsIdentity is the only signing certificate identity
-	// accepted for the platform-endorsements artifact: the tag-triggered
-	// build workflow of the publisher repo. Dots are escaped and the pattern
-	// is anchored at both ends so no other workflow path, ref type, or
-	// trailing SAN content can match.
-	platformEndorsementsIdentity = "^https://github\\.com/" + platformEndorsementsRepo +
-		"/\\.github/workflows/build\\.yml@refs/tags/v[0-9][^@]*$"
+// platformEndorsementsIdentity is the only signing certificate identity
+// accepted for the platform-endorsements artifact.
+var platformEndorsementsIdentity = githubActionsIdentity(
+	platformEndorsementsRepo,
+	"build\\.yml",
+	"refs/tags/v[0-9][^@]*",
 )
 
 type Client struct {
@@ -77,13 +77,17 @@ func FetchTrustRoot() ([]byte, error) {
 
 func (c *Client) VerifyBundle(bundleJSON []byte, repo, hexDigest string) (*verify.VerificationResult, error) {
 	// TODO: Can we pin this to latest without fetching the latest release?
-	sanRegex := "^https://github.com/" + repo + "/.github/workflows/.*@refs/tags/*"
+	sanRegex := githubActionsIdentity(repo, "[^@]+", "refs/tags/.+")
 	return c.verifyBundleWithIdentity(bundleJSON, sanRegex, hexDigest)
 }
 
 func releaseIdentity(repo, tag string) string {
+	return githubActionsIdentity(repo, "[^@]+", "refs/tags/"+regexp.QuoteMeta(tag))
+}
+
+func githubActionsIdentity(repo, workflowPattern, refPattern string) string {
 	return "^https://github\\.com/" + regexp.QuoteMeta(repo) +
-		"/\\.github/workflows/.*@refs/tags/" + regexp.QuoteMeta(tag) + "$"
+		"/\\.github/workflows/" + workflowPattern + "@" + refPattern + "$"
 }
 
 // verifyBundleWithIdentity verifies a Sigstore bundle against an explicit

--- a/verifier/sigstore/sigstore.go
+++ b/verifier/sigstore/sigstore.go
@@ -3,6 +3,7 @@ package sigstore
 import (
 	"encoding/hex"
 	"fmt"
+	"regexp"
 	"strings"
 
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
@@ -78,6 +79,11 @@ func (c *Client) VerifyBundle(bundleJSON []byte, repo, hexDigest string) (*verif
 	// TODO: Can we pin this to latest without fetching the latest release?
 	sanRegex := "^https://github.com/" + repo + "/.github/workflows/.*@refs/tags/*"
 	return c.verifyBundleWithIdentity(bundleJSON, sanRegex, hexDigest)
+}
+
+func releaseIdentity(repo, tag string) string {
+	return "^https://github\\.com/" + regexp.QuoteMeta(repo) +
+		"/\\.github/workflows/.*@refs/tags/" + regexp.QuoteMeta(tag) + "$"
 }
 
 // verifyBundleWithIdentity verifies a Sigstore bundle against an explicit
@@ -187,6 +193,19 @@ func (c *Client) VerifyAttestation(
 	repo, hexDigest string,
 ) (*attestation.Measurement, error) {
 	result, err := c.VerifyBundle(bundleJSON, repo, hexDigest)
+	return measurementFromResult(result, err)
+}
+
+// VerifyAttestationForRelease verifies an attestation signed for an exact release tag.
+func (c *Client) VerifyAttestationForRelease(
+	bundleJSON []byte,
+	repo, tag, hexDigest string,
+) (*attestation.Measurement, error) {
+	result, err := c.verifyBundleWithIdentity(bundleJSON, releaseIdentity(repo, tag), hexDigest)
+	return measurementFromResult(result, err)
+}
+
+func measurementFromResult(result *verify.VerificationResult, err error) (*attestation.Measurement, error) {
 	if err != nil {
 		return nil, fmt.Errorf("verifying bundle: %w", err)
 	}

--- a/verifier/sigstore/sigstore_test.go
+++ b/verifier/sigstore/sigstore_test.go
@@ -1,12 +1,22 @@
 package sigstore
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tinfoilsh/tinfoil-go/verifier/attestation"
 	"github.com/tinfoilsh/tinfoil-go/verifier/github"
 )
+
+func TestReleaseIdentityMatchesExactTag(t *testing.T) {
+	identity := regexp.MustCompile(releaseIdentity("owner/repo.name", "v1.2.3+build"))
+
+	assert.True(t, identity.MatchString("https://github.com/owner/repo.name/.github/workflows/build.yml@refs/tags/v1.2.3+build"))
+	assert.False(t, identity.MatchString("https://github.com/owner/repo.name/.github/workflows/build.yml@refs/tags/v1.2.4"))
+	assert.False(t, identity.MatchString("https://github.com/owner/repoXname/.github/workflows/build.yml@refs/tags/v1.2.3+build"))
+	assert.False(t, identity.MatchString("https://github.com/owner/repo.name/.github/workflows/build.yml@refs/tags/v1.2.3+build/extra"))
+}
 
 func TestFetchHardwarePlatformMeasurements(t *testing.T) {
 	if testing.Short() {

--- a/version.go
+++ b/version.go
@@ -1,0 +1,6 @@
+package tinfoil
+
+import "github.com/tinfoilsh/tinfoil-go/verifier/client"
+
+// Version is the Tinfoil Go SDK version.
+const Version = client.Version


### PR DESCRIPTION
## Summary
- add versioned verification documents with release, measurement, verifier, and completion-time provenance
- keep documents synchronized with active TLS and EHBP transports during key rotation
- prepare SDK version 0.15.0 and accept current signed platform endorsement metadata

## Testing
- `go test -race ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose a versioned verification provenance document and keep it synced with the active TLS/EHBP transport, including during rotations and Verify(). Hardened state so provenance always reflects the verified endpoint, stricter bundle domain checks, and centralized GitHub Actions identity patterns for Sigstore.

- **New Features**
  - Added `VerificationDocument()` on `Client`/`SecureClient` (plus JSON) with repo/tag, digest, verifier identity/version, `VerifiedAt`, and per-step status.
  - Unified verified transport state; rotations and `Verify()` atomically refresh transport + document, and document reads from the active transport.
  - Accepted current SEV‑SNP/TDX endorsement fields and translation updates (ABI, mitigation vectors, `mr_seam`, IDs, `MachineShape`, `AliasCheckComplete`).
  - Added `verifier/github.FetchLatestRelease()` and exact-tag Sigstore verification; SDK version set to `0.15.0` via `tinfoil.Version`.

- **Refactors**
  - Centralized Sigstore GitHub Actions identity patterns to ensure precise repo/workflow/ref matching.

<sup>Written for commit bbcfca47dea300d5494316b15b5463bc617b7e6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-go/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

