### PR TITLE
Feat/v3 conformance harness

### DIFF
--- a/cmd/tinfoil-conformance/capture.go
+++ b/cmd/tinfoil-conformance/capture.go
@@ -50,7 +50,7 @@ func runCapture(args []string) int {
 	// every future replay reproduces.
 	captureUnix := time.Now().Unix()
 	in := conformance.Input{
-		SchemaVersion:        "1",
+		SchemaVersion:        conformance.SchemaVersion,
 		DocumentB64:          base64.StdEncoding.EncodeToString(doc),
 		NonceHex:             hex.EncodeToString(nonce),
 		Repo:                 *repo,

--- a/cmd/tinfoil-conformance/capture.go
+++ b/cmd/tinfoil-conformance/capture.go
@@ -82,7 +82,10 @@ func runCapture(args []string) int {
 	b = append(b, '\n')
 
 	if *out == "" {
-		os.Stdout.Write(b)
+		if _, err := os.Stdout.Write(b); err != nil {
+			fmt.Fprintf(os.Stderr, "writing fixture: %v\n", err)
+			return conformance.ExitInternal
+		}
 	} else if err := os.WriteFile(*out, b, 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "writing %s: %v\n", *out, err)
 		return conformance.ExitInternal

--- a/cmd/tinfoil-conformance/capture.go
+++ b/cmd/tinfoil-conformance/capture.go
@@ -1,0 +1,108 @@
+//go:build tinfoil_conformance
+
+package main
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/tinfoilsh/tinfoil-go/verifier/conformance"
+	"github.com/tinfoilsh/tinfoil-go/verifier/envelope"
+)
+
+// runCapture fetches a v3 attestation from a live enclave and, only if it
+// verifies against the embedded production roots, freezes it as a real-frozen
+// fixture pinned to its capture time — the accepting embedded-root oracle that
+// synthetic fixtures cannot produce.
+func runCapture(args []string) int {
+	fs := flag.NewFlagSet("capture", flag.ContinueOnError)
+	host := fs.String("host", "", "enclave host to fetch the v3 attestation from (e.g. inference.tinfoil.sh)")
+	repo := fs.String("repo", "", "pinned sigstore-code source repo (owner/name)")
+	id := fs.String("id", "real-frozen", "fixture id")
+	out := fs.String("out", "", "output fixture path (default: stdout)")
+	nonceHex := fs.String("nonce", "", "verifier nonce, lowercase hex (default: fresh random)")
+	if err := fs.Parse(args); err != nil {
+		return conformance.ExitMalformed
+	}
+	if *host == "" || *repo == "" {
+		fmt.Fprintln(os.Stderr, "usage: tinfoil-conformance capture -host <enclave> -repo <owner/name> [-id ..] [-out ..] [-nonce ..]")
+		return conformance.ExitMalformed
+	}
+
+	nonce, err := resolveNonce(*nonceHex)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "nonce: %v\n", err)
+		return conformance.ExitMalformed
+	}
+
+	doc, err := envelope.Fetch(*host, nonce)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fetching attestation from %s: %v\n", *host, err)
+		return conformance.ExitInternal
+	}
+
+	// Pin to the capture instant: collateral is fresh now, and this is what
+	// every future replay reproduces.
+	captureUnix := time.Now().Unix()
+	in := conformance.Input{
+		SchemaVersion:        "1",
+		DocumentB64:          base64.StdEncoding.EncodeToString(doc),
+		NonceHex:             hex.EncodeToString(nonce),
+		Repo:                 *repo,
+		VerificationTimeUnix: captureUnix,
+	}
+
+	// Verify through the real embedded-root path (empty anchors) at the pinned
+	// time before freezing; refuse to write a document the verifier rejects.
+	if outp, code := conformance.Run(conformance.StageVerify, in); code != conformance.ExitAccepted {
+		msg := "unknown"
+		if outp.Rejection != nil {
+			msg = outp.Rejection.Code
+		}
+		fmt.Fprintf(os.Stderr, "refusing to freeze: verification did not accept (exit %d, %s)\n", code, msg)
+		return code
+	}
+
+	fixture := map[string]any{
+		"id":       *id,
+		"stage":    conformance.StageVerify,
+		"input":    in,
+		"expected": map[string]any{"accepted": true},
+	}
+	b, err := json.MarshalIndent(fixture, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "encoding fixture: %v\n", err)
+		return conformance.ExitInternal
+	}
+	b = append(b, '\n')
+
+	if *out == "" {
+		os.Stdout.Write(b)
+	} else if err := os.WriteFile(*out, b, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "writing %s: %v\n", *out, err)
+		return conformance.ExitInternal
+	} else {
+		fmt.Fprintf(os.Stderr, "froze real v3 document -> %s (verified at capture time %d)\n", *out, captureUnix)
+	}
+	return conformance.ExitAccepted
+}
+
+// resolveNonce returns the supplied hex nonce or a fresh random one.
+func resolveNonce(h string) ([]byte, error) {
+	if h == "" {
+		return envelope.RandomNonce()
+	}
+	n, err := hex.DecodeString(h)
+	if err != nil {
+		return nil, err
+	}
+	if len(n) != envelope.NonceSize {
+		return nil, fmt.Errorf("nonce must be %d bytes, got %d", envelope.NonceSize, len(n))
+	}
+	return n, nil
+}

--- a/cmd/tinfoil-conformance/live.go
+++ b/cmd/tinfoil-conformance/live.go
@@ -1,0 +1,96 @@
+//go:build tinfoil_conformance
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/tinfoilsh/tinfoil-go/verifier/client"
+	"github.com/tinfoilsh/tinfoil-go/verifier/conformance"
+	"github.com/tinfoilsh/tinfoil-go/verifier/envelope"
+)
+
+const stageLive = "live-verify"
+
+// liveRequest is the integration-lane stdin JSON (spec §7).
+type liveRequest struct {
+	Host string `json:"host"`
+	Repo string `json:"repo"`
+}
+
+// runLive verifies a live enclave through the SDK's public production entry
+// point — client.VerifyDocumentV3 with embedded roots and the current time,
+// never the adapter's composed flow or injected seams — then asserts the live
+// connection's SPKI fingerprint equals the endorsed one before reporting the
+// facts with channel_binding "tls-spki".
+func runLive() int {
+	var req liveRequest
+	dec := json.NewDecoder(os.Stdin)
+	if err := dec.Decode(&req); err != nil || dec.Decode(new(any)) != io.EOF || req.Host == "" || req.Repo == "" {
+		writeJSON(conformance.Output{Stage: stageLive, Rejection: &conformance.Rejection{Code: "MALFORMED_INPUT"}})
+		return conformance.ExitMalformed
+	}
+
+	nonce, err := envelope.RandomNonce()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "nonce: %v\n", err)
+		return conformance.ExitInternal
+	}
+	doc, err := envelope.Fetch(req.Host, nonce)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fetching attestation from %s: %v\n", req.Host, err)
+		return conformance.ExitInternal
+	}
+
+	verified, err := client.VerifyDocumentV3(doc, nonce, req.Repo)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "live verification: %v\n", err)
+		return rejectLive(conformance.RejectionCode(err))
+	}
+	tlsFP, err := verified.TLSPublicKeyFP()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "endorsed keys: %v\n", err)
+		return rejectLive("ENVELOPE_REJECTED")
+	}
+	hpke, err := verified.HPKEPublicKey()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "endorsed keys: %v\n", err)
+		return rejectLive("ENVELOPE_REJECTED")
+	}
+
+	// Channel binding: the endorsed TLS key must be the key the live enclave
+	// actually presents on the wire.
+	live, err := conformance.TLSSPKIFingerprint(req.Host)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "dialing %s for channel binding: %v\n", req.Host, err)
+		return conformance.ExitInternal
+	}
+	if live != tlsFP {
+		fmt.Fprintf(os.Stderr, "channel binding: live TLS key %s != endorsed %s\n", live, tlsFP)
+		return rejectLive("POLICY_REJECTED")
+	}
+
+	writeJSON(conformance.Output{Stage: stageLive, Accepted: true, Outputs: &conformance.AcceptOutputs{
+		CodeDigest: verified.CodeDigest,
+		CodeMeasurement: conformance.Measurement{
+			Type:      string(verified.CodeMeasurement.Type),
+			Registers: verified.CodeMeasurement.Registers,
+		},
+		EnclaveMeasurement: conformance.Measurement{
+			Type:      string(verified.EnclaveMeasurement.Type),
+			Registers: verified.EnclaveMeasurement.Registers,
+		},
+		TLSPublicKeyFP: tlsFP,
+		HPKEPublicKey:  hpke,
+		ChannelBinding: "tls-spki",
+	}})
+	return conformance.ExitAccepted
+}
+
+func rejectLive(code string) int {
+	writeJSON(conformance.Output{Stage: stageLive, Accepted: false, Rejection: &conformance.Rejection{Code: code}})
+	return conformance.ExitRejected
+}

--- a/cmd/tinfoil-conformance/main.go
+++ b/cmd/tinfoil-conformance/main.go
@@ -6,6 +6,8 @@
 // `tinfoil-conformance capabilities` prints the SDK's capabilities.
 // `tinfoil-conformance capture` fetches a live enclave's v3 attestation and
 // freezes it as a real-frozen fixture (see capture.go).
+// `tinfoil-conformance live-verify` verifies a live enclave through the public
+// production entry point and binds the TLS channel (see live.go).
 package main
 
 import (
@@ -19,7 +21,7 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: tinfoil-conformance <stage>|capabilities|capture")
+		fmt.Fprintln(os.Stderr, "usage: tinfoil-conformance <stage>|capabilities|capture|live-verify")
 		os.Exit(conformance.ExitMalformed)
 	}
 	cmd := os.Args[1]
@@ -31,6 +33,10 @@ func main() {
 
 	if cmd == "capture" {
 		os.Exit(runCapture(os.Args[2:]))
+	}
+
+	if cmd == "live-verify" {
+		os.Exit(runLive())
 	}
 
 	var in conformance.Input

--- a/cmd/tinfoil-conformance/main.go
+++ b/cmd/tinfoil-conformance/main.go
@@ -18,8 +18,8 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: tinfoil-conformance <stage>|capabilities")
-		os.Exit(conformance.ExitInternal)
+		fmt.Fprintln(os.Stderr, "usage: tinfoil-conformance <stage>|capabilities|capture")
+		os.Exit(conformance.ExitMalformed)
 	}
 	cmd := os.Args[1]
 

--- a/cmd/tinfoil-conformance/main.go
+++ b/cmd/tinfoil-conformance/main.go
@@ -1,0 +1,50 @@
+//go:build tinfoil_conformance
+
+// Command tinfoil-conformance is the tinfoil-go conformance adapter the
+// cross-SDK suite invokes: `tinfoil-conformance <stage>` reads an Input JSON on
+// stdin and writes an Output JSON on stdout, exiting with the adapter code.
+// `tinfoil-conformance capabilities` prints the SDK's capabilities.
+// `tinfoil-conformance capture` fetches a live enclave's v3 attestation and
+// freezes it as a real-frozen fixture (see capture.go).
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/tinfoilsh/tinfoil-go/verifier/conformance"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: tinfoil-conformance <stage>|capabilities")
+		os.Exit(conformance.ExitInternal)
+	}
+	cmd := os.Args[1]
+
+	if cmd == "capabilities" {
+		writeJSON(conformance.Capabilities())
+		return
+	}
+
+	if cmd == "capture" {
+		os.Exit(runCapture(os.Args[2:]))
+	}
+
+	var in conformance.Input
+	if err := json.NewDecoder(os.Stdin).Decode(&in); err != nil {
+		writeJSON(conformance.Output{Stage: cmd, Rejection: &conformance.Rejection{Code: "MALFORMED_INPUT"}})
+		os.Exit(conformance.ExitMalformed)
+	}
+
+	out, code := conformance.Run(cmd, in)
+	writeJSON(out)
+	os.Exit(code)
+}
+
+func writeJSON(v any) {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(v)
+}

--- a/cmd/tinfoil-conformance/main.go
+++ b/cmd/tinfoil-conformance/main.go
@@ -11,6 +11,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/tinfoilsh/tinfoil-go/verifier/conformance"
@@ -33,7 +34,9 @@ func main() {
 	}
 
 	var in conformance.Input
-	if err := json.NewDecoder(os.Stdin).Decode(&in); err != nil {
+	dec := json.NewDecoder(os.Stdin)
+	if err := dec.Decode(&in); err != nil || dec.Decode(new(any)) != io.EOF {
+		// Exactly one JSON value: trailing data is malformed input.
 		writeJSON(conformance.Output{Stage: cmd, Rejection: &conformance.Rejection{Code: "MALFORMED_INPUT"}})
 		os.Exit(conformance.ExitMalformed)
 	}
@@ -46,5 +49,8 @@ func main() {
 func writeJSON(v any) {
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
-	_ = enc.Encode(v)
+	if err := enc.Encode(v); err != nil {
+		fmt.Fprintf(os.Stderr, "writing output: %v\n", err)
+		os.Exit(conformance.ExitInternal)
+	}
 }

--- a/cmd/tinfoil-conformance/main_stub.go
+++ b/cmd/tinfoil-conformance/main_stub.go
@@ -1,0 +1,15 @@
+//go:build !tinfoil_conformance
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// The conformance adapter is a test surface, built only with
+// -tags tinfoil_conformance. Production builds get this stub.
+func main() {
+	fmt.Fprintln(os.Stderr, "tinfoil-conformance: rebuild with -tags tinfoil_conformance")
+	os.Exit(2)
+}

--- a/verifier/conformance/capabilities.go
+++ b/verifier/conformance/capabilities.go
@@ -1,0 +1,18 @@
+//go:build tinfoil_conformance
+
+package conformance
+
+// Capabilities is the adapter's self-description; the suite reads it to gate
+// which fixtures this SDK can run. Same shape across languages.
+func Capabilities() map[string]any {
+	return map[string]any{
+		"schema_version": "1",
+		"sdk":            "tinfoil-go",
+		"v3": map[string]any{
+			"supported":          true,
+			"stages_supported":   []string{StageVerify, StageCheckEnvelope, StageAuthenticateProvenance, StageAssemblePolicy, StageAuthenticateQuote},
+			"synthetic_roots":    map[string]bool{"amd": true, "intel": true, "sigstore": true},
+			"freshness_enforced": false,
+		},
+	}
+}

--- a/verifier/conformance/capabilities.go
+++ b/verifier/conformance/capabilities.go
@@ -12,7 +12,7 @@ func Capabilities() map[string]any {
 			"supported":          true,
 			"stages_supported":   []string{StageVerify, StageCheckEnvelope, StageAuthenticateProvenance, StageAssemblePolicy, StageAuthenticateQuote},
 			"synthetic_roots":    map[string]bool{"amd": true, "intel": true, "sigstore": true},
-			"freshness_enforced": false,
+			"freshness_enforced": true,
 		},
 	}
 }

--- a/verifier/conformance/capabilities.go
+++ b/verifier/conformance/capabilities.go
@@ -2,12 +2,19 @@
 
 package conformance
 
+// SchemaVersion is the adapter wire-contract version; SDKName identifies this
+// adapter in capabilities output.
+const (
+	SchemaVersion = "1"
+	SDKName       = "tinfoil-go"
+)
+
 // Capabilities is the adapter's self-description; the suite reads it to gate
 // which fixtures this SDK can run. Same shape across languages.
 func Capabilities() map[string]any {
 	return map[string]any{
-		"schema_version": "1",
-		"sdk":            "tinfoil-go",
+		"schema_version": SchemaVersion,
+		"sdk":            SDKName,
 		"v3": map[string]any{
 			"supported":          true,
 			"stages_supported":   []string{StageVerify, StageCheckEnvelope, StageAuthenticateProvenance, StageAssemblePolicy, StageAuthenticateQuote},

--- a/verifier/conformance/capabilities.go
+++ b/verifier/conformance/capabilities.go
@@ -20,6 +20,8 @@ func Capabilities() map[string]any {
 			"stages_supported":   []string{StageVerify, StageCheckEnvelope, StageAuthenticateProvenance, StageAssemblePolicy, StageAuthenticateQuote},
 			"synthetic_roots":    map[string]bool{"amd": true, "intel": true, "sigstore": true},
 			"freshness_enforced": true,
+			"live_verify":        true,
+			"channel_binding":    "tls-spki",
 		},
 	}
 }

--- a/verifier/conformance/conformance.go
+++ b/verifier/conformance/conformance.go
@@ -91,6 +91,9 @@ type AcceptOutputs struct {
 	// these is the point of verification, so every SDK must surface them.
 	TLSPublicKeyFP string `json:"tls_public_key_fp,omitempty"`
 	HPKEPublicKey  string `json:"hpke_public_key,omitempty"`
+	// ChannelBinding is set by the live-verify integration lane after the
+	// live transport key was matched against the endorsed one.
+	ChannelBinding string `json:"channel_binding,omitempty"`
 }
 
 // Measurement mirrors verifier/measurement.Measurement as plain JSON.

--- a/verifier/conformance/conformance.go
+++ b/verifier/conformance/conformance.go
@@ -103,6 +103,11 @@ type Rejection struct {
 }
 
 // Run executes one stage and returns the wire Output plus the adapter exit code.
+//
+// Run is single-call by contract: it pins process-wide seams (verification
+// clock, injected roots) for the duration of the call and restores them on
+// return. The adapter binary and the fixture runner invoke it sequentially;
+// it must not be called concurrently.
 func Run(stage string, in Input) (Output, int) {
 	// Pin the validity-window and freshness clock for a frozen document.
 	appraisal := time.Now()
@@ -217,7 +222,13 @@ func verifyFull(doc, nonce []byte, repo string, rts roots, prov provAuth, apprai
 	if err := assembled.Validate(); err != nil {
 		return reject(StageVerify, "POLICY_REJECTED")
 	}
+	// A document that verifies but endorses no usable channel keys is useless
+	// to every real client (SecureClient rejects at binding), so the full
+	// stage requires both — mirroring the deployed end-to-end behavior.
 	tlsFP, hpke := boundKeys(parsed)
+	if tlsFP == "" || hpke == "" {
+		return reject(StageVerify, "ENVELOPE_REJECTED")
+	}
 	return Output{Stage: StageVerify, Accepted: true, Outputs: &AcceptOutputs{
 		CodeDigest:         code.Digest,
 		CodeMeasurement:    toMeasurement(code.Measurement),

--- a/verifier/conformance/conformance.go
+++ b/verifier/conformance/conformance.go
@@ -84,6 +84,11 @@ type AcceptOutputs struct {
 	CodeDigest         string      `json:"code_digest"`
 	CodeMeasurement    Measurement `json:"code_measurement"`
 	EnclaveMeasurement Measurement `json:"enclave_measurement"`
+	// Endorsed channel keys the caller binds its connection to: the TLS SPKI
+	// fingerprint and HPKE public key, hash-bound into the quote. Recovering
+	// these is the point of verification, so every SDK must surface them.
+	TLSPublicKeyFP string `json:"tls_public_key_fp,omitempty"`
+	HPKEPublicKey  string `json:"hpke_public_key,omitempty"`
 }
 
 // Measurement mirrors verifier/measurement.Measurement as plain JSON.
@@ -212,11 +217,28 @@ func verifyFull(doc, nonce []byte, repo string, rts roots, prov provAuth, apprai
 	if err := assembled.Validate(); err != nil {
 		return reject(StageVerify, "POLICY_REJECTED")
 	}
+	tlsFP, hpke := boundKeys(parsed)
 	return Output{Stage: StageVerify, Accepted: true, Outputs: &AcceptOutputs{
 		CodeDigest:         code.Digest,
 		CodeMeasurement:    toMeasurement(code.Measurement),
 		EnclaveMeasurement: toMeasurement(auth.Measurement),
+		TLSPublicKeyFP:     tlsFP,
+		HPKEPublicKey:      hpke,
 	}}, ExitAccepted
+}
+
+// boundKeys returns the endorsed TLS SPKI fingerprint and HPKE public key from
+// the verified crypto material (hash-bound into the quote via envelope.Check).
+func boundKeys(doc *envelope.Document) (tlsFP, hpke string) {
+	for _, it := range doc.CryptoMaterialItems() {
+		switch {
+		case it.ID == envelope.CryptoMaterialIDTLS && it.Format == envelope.KeySPKIFPSHA256V1Format:
+			tlsFP = it.Data
+		case it.ID == envelope.CryptoMaterialIDHPKE && it.Format == envelope.KeyX25519HPKEV1Format:
+			hpke = it.Data
+		}
+	}
+	return
 }
 
 // authReferenceValues authenticates the code and platform artifacts and their

--- a/verifier/conformance/conformance.go
+++ b/verifier/conformance/conformance.go
@@ -119,6 +119,9 @@ func Run(stage string, in Input) (Output, int) {
 		defer tdx.ResetVerificationTime()
 	}
 
+	if in.SchemaVersion != SchemaVersion {
+		return malformed(stage, fmt.Errorf("schema_version %q, want %q", in.SchemaVersion, SchemaVersion))
+	}
 	doc, err := base64.StdEncoding.DecodeString(in.DocumentB64)
 	if err != nil {
 		return malformed(stage, fmt.Errorf("document_b64: %w", err))

--- a/verifier/conformance/conformance.go
+++ b/verifier/conformance/conformance.go
@@ -1,0 +1,344 @@
+//go:build tinfoil_conformance
+
+// Package conformance is the tinfoil-go v3 conformance adapter: it runs shared
+// cross-SDK fixtures against the verifier and reports the result in the
+// language-neutral wire contract below. Every SDK implements the same
+// Input/Output shapes and exit codes so the suite drives them identically.
+//
+// The full-verify stage composes the verification flow step by step (rather
+// than calling client.VerifyDocumentV3) so it can inject synthetic roots via
+// the tag-gated seams, pin the freshness appraisal time for frozen documents,
+// and attribute a rejection to the failing layer — all with no production
+// change beyond those seams.
+package conformance
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/tinfoilsh/tinfoil-go/verifier/envelope"
+	"github.com/tinfoilsh/tinfoil-go/verifier/measurement"
+	"github.com/tinfoilsh/tinfoil-go/verifier/provenance"
+	"github.com/tinfoilsh/tinfoil-go/verifier/quote"
+	"github.com/tinfoilsh/tinfoil-go/verifier/quote/sev"
+	"github.com/tinfoilsh/tinfoil-go/verifier/quote/tdx"
+)
+
+// Exit codes are the cross-SDK adapter contract: the suite reads them to decide
+// pass/skip and never depends on stdout for the verdict.
+const (
+	ExitAccepted    = 0  // verification accepted; Output.Outputs populated
+	ExitInternal    = 1  // unexpected adapter error
+	ExitRejected    = 10 // verification rejected; Output.Rejection populated
+	ExitUnsupported = 20 // stage/capability not supported by this SDK
+	ExitMalformed   = 30 // input did not parse
+)
+
+// Stages this adapter handles. The full stage runs the whole flow including
+// freshness; the block stages isolate a single layer.
+const (
+	StageVerify                 = "verify-attestation-v3"      // full envelope→provenance→freshness→quote→policy
+	StageCheckEnvelope          = "v3-check-envelope"          // strict parse + nonce/hash/report-data binding
+	StageAuthenticateProvenance = "v3-authenticate-provenance" // sigstore-code identity + measurement
+	StageAssemblePolicy         = "v3-assemble-policy"         // sigstore-platform endorsements artifact
+	StageAuthenticateQuote      = "v3-authenticate-quote"      // CPU quote signature chain to the vendor root
+)
+
+// Input is the stdin JSON: a v3 document, the verifier-supplied nonce, the
+// pinned repo, and the synthetic roots it was produced under. Empty root fields
+// select the embedded production roots (so real-frozen fixtures need none).
+type Input struct {
+	SchemaVersion string `json:"schema_version"`
+	DocumentB64   string `json:"document_b64"`
+	NonceHex      string `json:"nonce_hex"`
+	Repo          string `json:"repo"`
+
+	// AMD SEV-SNP anchor, supplied as the ARK plus its ASK (KDS convention).
+	AMDRootCAPEM string `json:"amd_root_ca_pem,omitempty"`
+	ASKPEM       string `json:"ask_pem,omitempty"`
+	// Intel TDX anchor.
+	IntelSGXRootPEM string `json:"intel_sgx_root_pem,omitempty"`
+	// Sigstore trusted-root document, base64 (JSON bytes).
+	SigstoreTrustedRootB64 string `json:"sigstore_trusted_root_json_b64,omitempty"`
+
+	// VerificationTimeUnix pins the validity-window and freshness-appraisal
+	// clock so a frozen document replays at its capture time; 0 uses the
+	// current time.
+	VerificationTimeUnix int64 `json:"verification_time_unix,omitempty"`
+}
+
+// Output is the stdout JSON. Exactly one of Outputs / Rejection is set.
+type Output struct {
+	Stage     string         `json:"stage"`
+	Accepted  bool           `json:"accepted"`
+	Outputs   *AcceptOutputs `json:"outputs,omitempty"`
+	Rejection *Rejection     `json:"rejection,omitempty"`
+}
+
+// AcceptOutputs are the verified facts, in a shape every SDK can produce and
+// the suite can diff for cross-SDK equivalence.
+type AcceptOutputs struct {
+	CodeDigest         string      `json:"code_digest"`
+	CodeMeasurement    Measurement `json:"code_measurement"`
+	EnclaveMeasurement Measurement `json:"enclave_measurement"`
+}
+
+// Measurement mirrors verifier/measurement.Measurement as plain JSON.
+type Measurement struct {
+	Type      string   `json:"type"`
+	Registers []string `json:"registers"`
+}
+
+// Rejection carries a coarse, layer-tagged code, stable across SDKs.
+type Rejection struct {
+	Code string `json:"code"`
+}
+
+// Run executes one stage and returns the wire Output plus the adapter exit code.
+func Run(stage string, in Input) (Output, int) {
+	// Pin the validity-window and freshness clock for a frozen document.
+	appraisal := time.Now()
+	if in.VerificationTimeUnix != 0 {
+		appraisal = time.Unix(in.VerificationTimeUnix, 0)
+		sev.SetVerificationTime(appraisal)
+		tdx.SetVerificationTime(appraisal)
+		defer sev.ResetVerificationTime()
+		defer tdx.ResetVerificationTime()
+	}
+
+	doc, err := base64.StdEncoding.DecodeString(in.DocumentB64)
+	if err != nil {
+		return malformed(stage, fmt.Errorf("document_b64: %w", err))
+	}
+	nonce, err := hex.DecodeString(in.NonceHex)
+	if err != nil {
+		return malformed(stage, fmt.Errorf("nonce_hex: %w", err))
+	}
+	rts, err := in.roots()
+	if err != nil {
+		return malformed(stage, err)
+	}
+	prov, err := newProvAuth(rts.sigstore)
+	if err != nil {
+		return malformed(stage, err)
+	}
+
+	switch stage {
+	case StageVerify:
+		return verifyFull(doc, nonce, in.Repo, rts, prov, appraisal)
+	case StageCheckEnvelope:
+		if _, _, err := envelope.Check(doc, nonce); err != nil {
+			return reject(stage, "ENVELOPE_REJECTED")
+		}
+		return Output{Stage: stage, Accepted: true}, ExitAccepted
+	case StageAuthenticateProvenance:
+		parsed, err := envelope.Parse(doc)
+		if err != nil {
+			return malformed(stage, fmt.Errorf("envelope: %w", err))
+		}
+		codeRef, err := parsed.ReferenceValuesCollateral(envelope.CollateralSigstoreCodeV1Format)
+		if err != nil {
+			return reject(stage, "PROVENANCE_REJECTED")
+		}
+		code, err := prov.code(codeRef.SigstoreBundle, in.Repo, codeRef.Tag, codeRef.Digest)
+		if err != nil {
+			return reject(stage, "PROVENANCE_REJECTED")
+		}
+		return Output{Stage: stage, Accepted: true, Outputs: &AcceptOutputs{
+			CodeDigest:      code.Digest,
+			CodeMeasurement: toMeasurement(code.Measurement),
+		}}, ExitAccepted
+	case StageAssemblePolicy:
+		parsed, err := envelope.Parse(doc)
+		if err != nil {
+			return malformed(stage, fmt.Errorf("envelope: %w", err))
+		}
+		platRef, err := parsed.ReferenceValuesCollateral(envelope.CollateralSigstorePlatformV1Format)
+		if err != nil {
+			return reject(stage, "PROVENANCE_REJECTED")
+		}
+		if _, err := prov.platform(platRef.SigstoreBundle, platRef.Repo, platRef.Tag, platRef.Digest); err != nil {
+			return reject(stage, "PROVENANCE_REJECTED")
+		}
+		return Output{Stage: stage, Accepted: true}, ExitAccepted
+	case StageAuthenticateQuote:
+		parsed, err := envelope.Parse(doc)
+		if err != nil {
+			return malformed(stage, fmt.Errorf("envelope: %w", err))
+		}
+		undo, err := setQuoteRoots(rts)
+		if err != nil {
+			return malformed(stage, err)
+		}
+		defer undo()
+		auth, err := quote.Authenticate(parsed)
+		if err != nil {
+			return reject(stage, "QUOTE_REJECTED")
+		}
+		return Output{Stage: stage, Accepted: true, Outputs: &AcceptOutputs{
+			EnclaveMeasurement: toMeasurement(auth.Measurement),
+		}}, ExitAccepted
+	default:
+		return Output{Stage: stage}, ExitUnsupported
+	}
+}
+
+// verifyFull composes the whole flow; the first failing step names the layer.
+func verifyFull(doc, nonce []byte, repo string, rts roots, prov provAuth, appraisal time.Time) (Output, int) {
+	parsed, reportData, err := envelope.Check(doc, nonce)
+	if err != nil {
+		return reject(StageVerify, "ENVELOPE_REJECTED")
+	}
+	code, endorsements, err := authReferenceValues(parsed, repo, prov, appraisal)
+	if err != nil {
+		return reject(StageVerify, "PROVENANCE_REJECTED")
+	}
+	undo, err := setQuoteRoots(rts)
+	if err != nil {
+		return malformed(StageVerify, err)
+	}
+	defer undo()
+	auth, err := quote.Authenticate(parsed)
+	if err != nil {
+		return reject(StageVerify, "QUOTE_REJECTED")
+	}
+	assembled, err := quote.Assemble(endorsements.Artifact, code.Measurement, code.Shape, reportData, auth)
+	if err != nil {
+		return reject(StageVerify, "POLICY_REJECTED")
+	}
+	if err := assembled.Validate(); err != nil {
+		return reject(StageVerify, "POLICY_REJECTED")
+	}
+	return Output{Stage: StageVerify, Accepted: true, Outputs: &AcceptOutputs{
+		CodeDigest:         code.Digest,
+		CodeMeasurement:    toMeasurement(code.Measurement),
+		EnclaveMeasurement: toMeasurement(auth.Measurement),
+	}}, ExitAccepted
+}
+
+// authReferenceValues authenticates the code and platform artifacts and their
+// freshness proofs, mirroring the production reference-values step.
+func authReferenceValues(doc *envelope.Document, repo string, prov provAuth, appraisal time.Time) (*provenance.Code, *provenance.PlatformEndorsements, error) {
+	codeRef, err := doc.ReferenceValuesCollateral(envelope.CollateralSigstoreCodeV1Format)
+	if err != nil {
+		return nil, nil, err
+	}
+	code, err := prov.code(codeRef.SigstoreBundle, repo, codeRef.Tag, codeRef.Digest)
+	if err != nil {
+		return nil, nil, err
+	}
+	codeFresh, err := doc.FreshnessCollateral(envelope.FreshnessCollateralIDCode)
+	if err != nil {
+		return nil, nil, err
+	}
+	if _, err := prov.freshness(codeFresh.SigstoreBundle, &code.AuthenticatedArtifact, appraisal); err != nil {
+		return nil, nil, err
+	}
+	platRef, err := doc.ReferenceValuesCollateral(envelope.CollateralSigstorePlatformV1Format)
+	if err != nil {
+		return nil, nil, err
+	}
+	endorsements, err := prov.platform(platRef.SigstoreBundle, platRef.Repo, platRef.Tag, platRef.Digest)
+	if err != nil {
+		return nil, nil, err
+	}
+	platFresh, err := doc.FreshnessCollateral(envelope.FreshnessCollateralIDPlatform)
+	if err != nil {
+		return nil, nil, err
+	}
+	if _, err := prov.freshness(platFresh.SigstoreBundle, &endorsements.AuthenticatedArtifact, appraisal); err != nil {
+		return nil, nil, err
+	}
+	return code, endorsements, nil
+}
+
+// roots are the injected synthetic anchors; a nil field selects the embedded
+// production root.
+type roots struct {
+	amd      []byte // ASK+ARK KDS chain
+	intel    []byte // Intel SGX root PEM
+	sigstore []byte // Sigstore trusted-root JSON
+}
+
+func (in Input) roots() (roots, error) {
+	var r roots
+	switch {
+	case in.AMDRootCAPEM != "" && in.ASKPEM != "":
+		// KDS cert_chain is ASK then ARK.
+		r.amd = []byte(strings.TrimSpace(in.ASKPEM) + "\n" + strings.TrimSpace(in.AMDRootCAPEM) + "\n")
+	case in.AMDRootCAPEM != "" || in.ASKPEM != "":
+		return r, fmt.Errorf("amd_root_ca_pem and ask_pem must be supplied together")
+	}
+	if in.IntelSGXRootPEM != "" {
+		r.intel = []byte(in.IntelSGXRootPEM)
+	}
+	if in.SigstoreTrustedRootB64 != "" {
+		j, err := base64.StdEncoding.DecodeString(in.SigstoreTrustedRootB64)
+		if err != nil {
+			return r, fmt.Errorf("sigstore_trusted_root_json_b64: %w", err)
+		}
+		r.sigstore = j
+	}
+	return r, nil
+}
+
+// setQuoteRoots injects the vendor roots for quote.Authenticate and returns an
+// undo that restores the embedded roots.
+func setQuoteRoots(rts roots) (func(), error) {
+	var undo []func()
+	reset := func() {
+		for i := len(undo) - 1; i >= 0; i-- {
+			undo[i]()
+		}
+	}
+	if rts.amd != nil {
+		sev.SetAMDRoot(rts.amd)
+		undo = append(undo, sev.ResetAMDRoot)
+	}
+	if rts.intel != nil {
+		if err := tdx.SetIntelRoot(rts.intel); err != nil {
+			reset()
+			return nil, err
+		}
+		undo = append(undo, tdx.ResetIntelRoot)
+	}
+	return reset, nil
+}
+
+// provAuth authenticates provenance against an injected Sigstore root, or the
+// embedded root when none was supplied. The package functions and the
+// per-client methods share signatures, so this is just method-value binding.
+type provAuth struct {
+	code      func(bundleJSON []byte, repo, tag, hexDigest string) (*provenance.Code, error)
+	platform  func(bundleJSON []byte, repo, tag, hexDigest string) (*provenance.PlatformEndorsements, error)
+	freshness func(bundleJSON []byte, expected *provenance.AuthenticatedArtifact, now time.Time) (time.Time, error)
+}
+
+func newProvAuth(sigstoreRootJSON []byte) (provAuth, error) {
+	if sigstoreRootJSON == nil {
+		return provAuth{provenance.AuthenticateCode, provenance.AuthenticatePlatformEndorsements, provenance.AuthenticateFreshness}, nil
+	}
+	c, err := provenance.NewClientFromJSON(sigstoreRootJSON)
+	if err != nil {
+		return provAuth{}, fmt.Errorf("sigstore_trusted_root_json_b64: %w", err)
+	}
+	return provAuth{c.AuthenticateCode, c.AuthenticatePlatformEndorsements, c.AuthenticateFreshness}, nil
+}
+
+func toMeasurement(m *measurement.Measurement) Measurement {
+	if m == nil {
+		return Measurement{}
+	}
+	return Measurement{Type: string(m.Type), Registers: m.Registers}
+}
+
+func reject(stage, code string) (Output, int) {
+	return Output{Stage: stage, Accepted: false, Rejection: &Rejection{Code: code}}, ExitRejected
+}
+
+func malformed(stage string, _ error) (Output, int) {
+	return Output{Stage: stage, Accepted: false, Rejection: &Rejection{Code: "MALFORMED_INPUT"}}, ExitMalformed
+}

--- a/verifier/conformance/conformance.go
+++ b/verifier/conformance/conformance.go
@@ -81,9 +81,9 @@ type Output struct {
 // AcceptOutputs are the verified facts, in a shape every SDK can produce and
 // the suite can diff for cross-SDK equivalence.
 type AcceptOutputs struct {
-	CodeDigest         string      `json:"code_digest"`
-	CodeMeasurement    Measurement `json:"code_measurement"`
-	EnclaveMeasurement Measurement `json:"enclave_measurement"`
+	CodeDigest         string      `json:"code_digest,omitempty"`
+	CodeMeasurement    Measurement `json:"code_measurement,omitzero"`
+	EnclaveMeasurement Measurement `json:"enclave_measurement,omitzero"`
 	// Endorsed channel keys the caller binds its connection to: the TLS SPKI
 	// fingerprint and HPKE public key, hash-bound into the quote. Recovering
 	// these is the point of verification, so every SDK must surface them.

--- a/verifier/conformance/conformance.go
+++ b/verifier/conformance/conformance.go
@@ -70,7 +70,9 @@ type Input struct {
 	VerificationTimeUnix int64 `json:"verification_time_unix,omitempty"`
 }
 
-// Output is the stdout JSON. Exactly one of Outputs / Rejection is set.
+// Output is the stdout JSON. Rejection is present iff Accepted is false;
+// Outputs is present on accepts that carry verified facts (block-stage
+// accepts may carry neither).
 type Output struct {
 	Stage     string         `json:"stage"`
 	Accepted  bool           `json:"accepted"`
@@ -120,23 +122,23 @@ func Run(stage string, in Input) (Output, int) {
 	}
 
 	if in.SchemaVersion != SchemaVersion {
-		return malformed(stage, fmt.Errorf("schema_version %q, want %q", in.SchemaVersion, SchemaVersion))
+		return malformed(stage)
 	}
 	doc, err := base64.StdEncoding.DecodeString(in.DocumentB64)
 	if err != nil {
-		return malformed(stage, fmt.Errorf("document_b64: %w", err))
+		return malformed(stage)
 	}
 	nonce, err := hex.DecodeString(in.NonceHex)
 	if err != nil {
-		return malformed(stage, fmt.Errorf("nonce_hex: %w", err))
+		return malformed(stage)
 	}
 	rts, err := in.roots()
 	if err != nil {
-		return malformed(stage, err)
+		return malformed(stage)
 	}
 	prov, err := newProvAuth(rts.sigstore)
 	if err != nil {
-		return malformed(stage, err)
+		return malformed(stage)
 	}
 
 	switch stage {
@@ -150,7 +152,7 @@ func Run(stage string, in Input) (Output, int) {
 	case StageAuthenticateProvenance:
 		parsed, err := envelope.Parse(doc)
 		if err != nil {
-			return malformed(stage, fmt.Errorf("envelope: %w", err))
+			return malformed(stage)
 		}
 		codeRef, err := parsed.ReferenceValuesCollateral(envelope.CollateralSigstoreCodeV1Format)
 		if err != nil {
@@ -167,7 +169,7 @@ func Run(stage string, in Input) (Output, int) {
 	case StageAssemblePolicy:
 		parsed, err := envelope.Parse(doc)
 		if err != nil {
-			return malformed(stage, fmt.Errorf("envelope: %w", err))
+			return malformed(stage)
 		}
 		platRef, err := parsed.ReferenceValuesCollateral(envelope.CollateralSigstorePlatformV1Format)
 		if err != nil {
@@ -180,11 +182,11 @@ func Run(stage string, in Input) (Output, int) {
 	case StageAuthenticateQuote:
 		parsed, err := envelope.Parse(doc)
 		if err != nil {
-			return malformed(stage, fmt.Errorf("envelope: %w", err))
+			return malformed(stage)
 		}
 		undo, err := setQuoteRoots(rts)
 		if err != nil {
-			return malformed(stage, err)
+			return malformed(stage)
 		}
 		defer undo()
 		auth, err := quote.Authenticate(parsed)
@@ -211,7 +213,7 @@ func verifyFull(doc, nonce []byte, repo string, rts roots, prov provAuth, apprai
 	}
 	undo, err := setQuoteRoots(rts)
 	if err != nil {
-		return malformed(StageVerify, err)
+		return malformed(StageVerify)
 	}
 	defer undo()
 	auth, err := quote.Authenticate(parsed)
@@ -375,6 +377,6 @@ func reject(stage, code string) (Output, int) {
 	return Output{Stage: stage, Accepted: false, Rejection: &Rejection{Code: code}}, ExitRejected
 }
 
-func malformed(stage string, _ error) (Output, int) {
+func malformed(stage string) (Output, int) {
 	return Output{Stage: stage, Accepted: false, Rejection: &Rejection{Code: "MALFORMED_INPUT"}}, ExitMalformed
 }

--- a/verifier/conformance/conformance_test.go
+++ b/verifier/conformance/conformance_test.go
@@ -1,0 +1,67 @@
+//go:build tinfoil_conformance
+
+package conformance
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fixture wraps the shared Input with the stage and expected outcome, for the
+// go-native runner. The Input sub-object is exactly what the CLI reads on stdin.
+type fixture struct {
+	ID       string `json:"id"`
+	Stage    string `json:"stage"`
+	Input    Input  `json:"input"`
+	Expected struct {
+		Accepted bool   `json:"accepted"`
+		Code     string `json:"code,omitempty"`
+	} `json:"expected"`
+}
+
+// TestFixtures runs every shared fixture in testdata/ through Run and asserts
+// the expected accept/reject. Coverage grows as fixtures are added.
+func TestFixtures(t *testing.T) {
+	// The shared fixtures live in the conformance suite; point the harness at
+	// them with TINFOIL_CONFORMANCE_FIXTURES, else fall back to local testdata.
+	dir := os.Getenv("TINFOIL_CONFORMANCE_FIXTURES")
+	if dir == "" {
+		dir = "testdata"
+	}
+	files, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Skip("no fixtures in testdata/")
+	}
+	for _, file := range files {
+		t.Run(filepath.Base(file), func(t *testing.T) {
+			data, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var f fixture
+			if err := json.Unmarshal(data, &f); err != nil {
+				t.Fatalf("loading fixture: %v", err)
+			}
+			out, _ := Run(f.Stage, f.Input)
+			if out.Accepted != f.Expected.Accepted {
+				t.Errorf("accepted=%v, want %v (rejection=%+v)", out.Accepted, f.Expected.Accepted, out.Rejection)
+			}
+			// When a reject fixture declares its spec-layer code, assert the
+			// harness attributed the rejection to that layer.
+			if !f.Expected.Accepted && f.Expected.Code != "" {
+				got := ""
+				if out.Rejection != nil {
+					got = out.Rejection.Code
+				}
+				if got != f.Expected.Code {
+					t.Errorf("rejection code=%q, want %q", got, f.Expected.Code)
+				}
+			}
+		})
+	}
+}

--- a/verifier/conformance/conformance_test.go
+++ b/verifier/conformance/conformance_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -16,10 +17,13 @@ type fixture struct {
 	Stage    string `json:"stage"`
 	Input    Input  `json:"input"`
 	Expected struct {
-		Accepted       bool   `json:"accepted"`
-		Code           string `json:"code,omitempty"`
-		TLSPublicKeyFP string `json:"tls_public_key_fp,omitempty"`
-		HPKEPublicKey  string `json:"hpke_public_key,omitempty"`
+		Accepted           bool         `json:"accepted"`
+		Code               string       `json:"code,omitempty"`
+		TLSPublicKeyFP     string       `json:"tls_public_key_fp,omitempty"`
+		HPKEPublicKey      string       `json:"hpke_public_key,omitempty"`
+		CodeDigest         string       `json:"code_digest,omitempty"`
+		CodeMeasurement    *Measurement `json:"code_measurement,omitempty"`
+		EnclaveMeasurement *Measurement `json:"enclave_measurement,omitempty"`
 	} `json:"expected"`
 }
 
@@ -64,18 +68,30 @@ func TestFixtures(t *testing.T) {
 					t.Errorf("rejection code=%q, want %q", got, f.Expected.Code)
 				}
 			}
-			// When an accept fixture declares the endorsed channel keys, assert
-			// the harness recovered exactly those — a client that fails to bind
-			// the right TLS/HPKE key is not conformant even if it accepts.
-			if f.Expected.Accepted && f.Expected.TLSPublicKeyFP != "" {
+			// When an accept fixture declares the verified facts, assert the
+			// harness recovered exactly those. A client that accepts but yields a
+			// different code digest, measurement register set, or channel key is
+			// not conformant — this is what forces cross-SDK output equivalence.
+			e := f.Expected
+			if e.Accepted && (e.TLSPublicKeyFP != "" || e.CodeDigest != "" || e.CodeMeasurement != nil || e.EnclaveMeasurement != nil) {
 				if out.Outputs == nil {
-					t.Fatalf("accepted but no outputs; want tls/hpke keys")
+					t.Fatalf("accepted but no outputs; want declared facts")
 				}
-				if out.Outputs.TLSPublicKeyFP != f.Expected.TLSPublicKeyFP {
-					t.Errorf("tls_public_key_fp=%q, want %q", out.Outputs.TLSPublicKeyFP, f.Expected.TLSPublicKeyFP)
+				o := out.Outputs
+				if e.TLSPublicKeyFP != "" && o.TLSPublicKeyFP != e.TLSPublicKeyFP {
+					t.Errorf("tls_public_key_fp=%q, want %q", o.TLSPublicKeyFP, e.TLSPublicKeyFP)
 				}
-				if out.Outputs.HPKEPublicKey != f.Expected.HPKEPublicKey {
-					t.Errorf("hpke_public_key=%q, want %q", out.Outputs.HPKEPublicKey, f.Expected.HPKEPublicKey)
+				if e.HPKEPublicKey != "" && o.HPKEPublicKey != e.HPKEPublicKey {
+					t.Errorf("hpke_public_key=%q, want %q", o.HPKEPublicKey, e.HPKEPublicKey)
+				}
+				if e.CodeDigest != "" && o.CodeDigest != e.CodeDigest {
+					t.Errorf("code_digest=%q, want %q", o.CodeDigest, e.CodeDigest)
+				}
+				if e.CodeMeasurement != nil && !reflect.DeepEqual(o.CodeMeasurement, *e.CodeMeasurement) {
+					t.Errorf("code_measurement=%+v, want %+v", o.CodeMeasurement, *e.CodeMeasurement)
+				}
+				if e.EnclaveMeasurement != nil && !reflect.DeepEqual(o.EnclaveMeasurement, *e.EnclaveMeasurement) {
+					t.Errorf("enclave_measurement=%+v, want %+v", o.EnclaveMeasurement, *e.EnclaveMeasurement)
 				}
 			}
 		})

--- a/verifier/conformance/conformance_test.go
+++ b/verifier/conformance/conformance_test.go
@@ -16,8 +16,10 @@ type fixture struct {
 	Stage    string `json:"stage"`
 	Input    Input  `json:"input"`
 	Expected struct {
-		Accepted bool   `json:"accepted"`
-		Code     string `json:"code,omitempty"`
+		Accepted       bool   `json:"accepted"`
+		Code           string `json:"code,omitempty"`
+		TLSPublicKeyFP string `json:"tls_public_key_fp,omitempty"`
+		HPKEPublicKey  string `json:"hpke_public_key,omitempty"`
 	} `json:"expected"`
 }
 
@@ -60,6 +62,20 @@ func TestFixtures(t *testing.T) {
 				}
 				if got != f.Expected.Code {
 					t.Errorf("rejection code=%q, want %q", got, f.Expected.Code)
+				}
+			}
+			// When an accept fixture declares the endorsed channel keys, assert
+			// the harness recovered exactly those — a client that fails to bind
+			// the right TLS/HPKE key is not conformant even if it accepts.
+			if f.Expected.Accepted && f.Expected.TLSPublicKeyFP != "" {
+				if out.Outputs == nil {
+					t.Fatalf("accepted but no outputs; want tls/hpke keys")
+				}
+				if out.Outputs.TLSPublicKeyFP != f.Expected.TLSPublicKeyFP {
+					t.Errorf("tls_public_key_fp=%q, want %q", out.Outputs.TLSPublicKeyFP, f.Expected.TLSPublicKeyFP)
+				}
+				if out.Outputs.HPKEPublicKey != f.Expected.HPKEPublicKey {
+					t.Errorf("hpke_public_key=%q, want %q", out.Outputs.HPKEPublicKey, f.Expected.HPKEPublicKey)
 				}
 			}
 		})

--- a/verifier/conformance/conformance_test.go
+++ b/verifier/conformance/conformance_test.go
@@ -73,7 +73,7 @@ func TestFixtures(t *testing.T) {
 			// different code digest, measurement register set, or channel key is
 			// not conformant — this is what forces cross-SDK output equivalence.
 			e := f.Expected
-			if e.Accepted && (e.TLSPublicKeyFP != "" || e.CodeDigest != "" || e.CodeMeasurement != nil || e.EnclaveMeasurement != nil) {
+			if e.Accepted && (e.TLSPublicKeyFP != "" || e.HPKEPublicKey != "" || e.CodeDigest != "" || e.CodeMeasurement != nil || e.EnclaveMeasurement != nil) {
 				if out.Outputs == nil {
 					t.Fatalf("accepted but no outputs; want declared facts")
 				}

--- a/verifier/conformance/doc.go
+++ b/verifier/conformance/doc.go
@@ -1,0 +1,4 @@
+// Package conformance runs the shared cross-SDK v3 attestation fixtures against
+// the verifier's injectable API. The runner and its tests build only with
+// -tags tinfoil_conformance; production builds see just this package clause.
+package conformance

--- a/verifier/conformance/live.go
+++ b/verifier/conformance/live.go
@@ -1,0 +1,51 @@
+//go:build tinfoil_conformance
+
+package conformance
+
+import (
+	"crypto/tls"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/tinfoilsh/tinfoil-go/verifier/client"
+)
+
+// RejectionCode maps a client.VerifyDocumentV3 error to the wire rejection
+// code by our own stable wrapping prefixes (verifier/client/verify.go) — not
+// by matching foreign error text. Policy failures surface under the cpu
+// evidence step in the public API, so they attribute as QUOTE_REJECTED.
+func RejectionCode(err error) string {
+	s := err.Error()
+	switch {
+	case strings.HasPrefix(s, "envelope:"):
+		return "ENVELOPE_REJECTED"
+	case strings.HasPrefix(s, "reference values:"):
+		return "PROVENANCE_REJECTED"
+	case strings.HasPrefix(s, "cpu evidence:"):
+		return "QUOTE_REJECTED"
+	}
+	return "ENVELOPE_REJECTED" // unreachable for the current wrapping
+}
+
+// TLSSPKIFingerprint dials host:443 and returns the SDK's canonical SPKI
+// fingerprint of the presented leaf (client.ConnectionCertFP — the same
+// computation TLSBoundRoundTripper enforces). Certificate-chain verification
+// is skipped on purpose: trust comes from matching the attested fingerprint,
+// not the public PKI.
+func TLSSPKIFingerprint(host string) (string, error) {
+	addr, serverName := host, host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		serverName = h // host already carries a port
+	} else {
+		addr = net.JoinHostPort(host, "443")
+	}
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	conn, err := tls.DialWithDialer(dialer, "tcp", addr,
+		&tls.Config{ServerName: serverName, InsecureSkipVerify: true}) //nolint:gosec // bound by SPKI, not PKI
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	return client.ConnectionCertFP(conn.ConnectionState())
+}

--- a/verifier/conformance/live_test.go
+++ b/verifier/conformance/live_test.go
@@ -3,8 +3,12 @@
 package conformance
 
 import (
+	"crypto/sha256"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/hex"
+	"fmt"
+	"net"
 	"os"
 	"testing"
 	"time"
@@ -51,10 +55,43 @@ func TestLiveVerification(t *testing.T) {
 	}
 	t.Logf("accepted: code_digest=%s enclave=%s", out.Outputs.CodeDigest, out.Outputs.EnclaveMeasurement.Type)
 
+	// Channel binding: the endorsed TLS key must be the key the live enclave
+	// actually presents on the wire. This is the whole point of attestation —
+	// verifying the document lets the caller trust this connection.
+	if fp := out.Outputs.TLSPublicKeyFP; fp != "" {
+		live, err := tlsSPKIFingerprint(host)
+		if err != nil {
+			t.Fatalf("dialing %s for channel binding: %v", host, err)
+		}
+		if live != fp {
+			t.Fatalf("channel binding: live TLS key %s != endorsed %s", live, fp)
+		}
+		t.Logf("channel bound: live TLS SPKI-fp matches the attested key %s", fp)
+	}
+
 	// The same bytes must still verify with the clock pinned to now — the
 	// contract a frozen real-frozen fixture relies on, checked on live collateral.
 	in.VerificationTimeUnix = time.Now().Unix()
 	if _, code := Run(StageVerify, in); code != ExitAccepted {
 		t.Fatalf("pinned-time replay of the live document did not accept (exit %d)", code)
 	}
+}
+
+// tlsSPKIFingerprint dials host:443 and returns the SHA-256 of the presented
+// leaf certificate's DER SubjectPublicKeyInfo, lowercase hex. Certificate-chain
+// verification is skipped on purpose: trust comes from matching this against
+// the attested fingerprint, not from the public PKI.
+func tlsSPKIFingerprint(host string) (string, error) {
+	conn, err := tls.Dial("tcp", net.JoinHostPort(host, "443"),
+		&tls.Config{ServerName: host, InsecureSkipVerify: true}) //nolint:gosec // bound by SPKI, not PKI
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	certs := conn.ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		return "", fmt.Errorf("no peer certificate")
+	}
+	sum := sha256.Sum256(certs[0].RawSubjectPublicKeyInfo)
+	return hex.EncodeToString(sum[:]), nil
 }

--- a/verifier/conformance/live_test.go
+++ b/verifier/conformance/live_test.go
@@ -3,15 +3,12 @@
 package conformance
 
 import (
-	"crypto/tls"
 	"encoding/base64"
 	"encoding/hex"
-	"net"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/tinfoilsh/tinfoil-go/verifier/client"
 	"github.com/tinfoilsh/tinfoil-go/verifier/envelope"
 )
 
@@ -58,7 +55,7 @@ func TestLiveVerification(t *testing.T) {
 	// actually presents on the wire. This is the whole point of attestation —
 	// verifying the document lets the caller trust this connection.
 	if fp := out.Outputs.TLSPublicKeyFP; fp != "" {
-		live, err := tlsSPKIFingerprint(host)
+		live, err := TLSSPKIFingerprint(host)
 		if err != nil {
 			t.Fatalf("dialing %s for channel binding: %v", host, err)
 		}
@@ -74,26 +71,4 @@ func TestLiveVerification(t *testing.T) {
 	if _, code := Run(StageVerify, in); code != ExitAccepted {
 		t.Fatalf("pinned-time replay of the live document did not accept (exit %d)", code)
 	}
-}
-
-// tlsSPKIFingerprint dials host:443 and returns the SDK's canonical SPKI
-// fingerprint of the presented leaf (client.ConnectionCertFP — the same
-// computation TLSBoundRoundTripper enforces). Certificate-chain verification is
-// skipped on purpose: trust comes from matching the attested fingerprint, not
-// the public PKI.
-func tlsSPKIFingerprint(host string) (string, error) {
-	addr, serverName := host, host
-	if h, _, err := net.SplitHostPort(host); err == nil {
-		serverName = h // host already carries a port
-	} else {
-		addr = net.JoinHostPort(host, "443")
-	}
-	dialer := &net.Dialer{Timeout: 10 * time.Second}
-	conn, err := tls.DialWithDialer(dialer, "tcp", addr,
-		&tls.Config{ServerName: serverName, InsecureSkipVerify: true}) //nolint:gosec // bound by SPKI, not PKI
-	if err != nil {
-		return "", err
-	}
-	defer conn.Close()
-	return client.ConnectionCertFP(conn.ConnectionState())
 }

--- a/verifier/conformance/live_test.go
+++ b/verifier/conformance/live_test.go
@@ -3,16 +3,15 @@
 package conformance
 
 import (
-	"crypto/sha256"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/hex"
-	"fmt"
 	"net"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/tinfoilsh/tinfoil-go/verifier/client"
 	"github.com/tinfoilsh/tinfoil-go/verifier/envelope"
 )
 
@@ -77,21 +76,18 @@ func TestLiveVerification(t *testing.T) {
 	}
 }
 
-// tlsSPKIFingerprint dials host:443 and returns the SHA-256 of the presented
-// leaf certificate's DER SubjectPublicKeyInfo, lowercase hex. Certificate-chain
-// verification is skipped on purpose: trust comes from matching this against
-// the attested fingerprint, not from the public PKI.
+// tlsSPKIFingerprint dials host:443 and returns the SDK's canonical SPKI
+// fingerprint of the presented leaf (client.ConnectionCertFP — the same
+// computation TLSBoundRoundTripper enforces). Certificate-chain verification is
+// skipped on purpose: trust comes from matching the attested fingerprint, not
+// the public PKI.
 func tlsSPKIFingerprint(host string) (string, error) {
-	conn, err := tls.Dial("tcp", net.JoinHostPort(host, "443"),
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	conn, err := tls.DialWithDialer(dialer, "tcp", net.JoinHostPort(host, "443"),
 		&tls.Config{ServerName: host, InsecureSkipVerify: true}) //nolint:gosec // bound by SPKI, not PKI
 	if err != nil {
 		return "", err
 	}
 	defer conn.Close()
-	certs := conn.ConnectionState().PeerCertificates
-	if len(certs) == 0 {
-		return "", fmt.Errorf("no peer certificate")
-	}
-	sum := sha256.Sum256(certs[0].RawSubjectPublicKeyInfo)
-	return hex.EncodeToString(sum[:]), nil
+	return client.ConnectionCertFP(conn.ConnectionState())
 }

--- a/verifier/conformance/live_test.go
+++ b/verifier/conformance/live_test.go
@@ -82,9 +82,15 @@ func TestLiveVerification(t *testing.T) {
 // skipped on purpose: trust comes from matching the attested fingerprint, not
 // the public PKI.
 func tlsSPKIFingerprint(host string) (string, error) {
+	addr, serverName := host, host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		serverName = h // host already carries a port
+	} else {
+		addr = net.JoinHostPort(host, "443")
+	}
 	dialer := &net.Dialer{Timeout: 10 * time.Second}
-	conn, err := tls.DialWithDialer(dialer, "tcp", net.JoinHostPort(host, "443"),
-		&tls.Config{ServerName: host, InsecureSkipVerify: true}) //nolint:gosec // bound by SPKI, not PKI
+	conn, err := tls.DialWithDialer(dialer, "tcp", addr,
+		&tls.Config{ServerName: serverName, InsecureSkipVerify: true}) //nolint:gosec // bound by SPKI, not PKI
 	if err != nil {
 		return "", err
 	}

--- a/verifier/conformance/live_test.go
+++ b/verifier/conformance/live_test.go
@@ -1,0 +1,60 @@
+//go:build tinfoil_conformance
+
+package conformance
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/tinfoilsh/tinfoil-go/verifier/envelope"
+)
+
+// TestLiveVerification fetches a v3 attestation from a real enclave and runs
+// the full flow against the embedded production roots (empty anchors) — the
+// accepting embedded-root path, on real hardware evidence, provenance, and
+// collateral. Opt-in via TINFOIL_LIVE_HOST so ordinary runs stay offline.
+//
+//	TINFOIL_LIVE_HOST=<enclave> TINFOIL_LIVE_REPO=<owner/name> \
+//	  go test -tags tinfoil_conformance -run TestLiveVerification ./verifier/conformance/
+func TestLiveVerification(t *testing.T) {
+	host := os.Getenv("TINFOIL_LIVE_HOST")
+	if host == "" {
+		t.Skip("set TINFOIL_LIVE_HOST (and TINFOIL_LIVE_REPO) to verify a live enclave")
+	}
+	repo := os.Getenv("TINFOIL_LIVE_REPO")
+
+	nonce, err := envelope.RandomNonce()
+	if err != nil {
+		t.Fatalf("nonce: %v", err)
+	}
+	doc, err := envelope.Fetch(host, nonce)
+	if err != nil {
+		t.Fatalf("fetch from %s: %v", host, err)
+	}
+
+	in := Input{
+		SchemaVersion: "1",
+		DocumentB64:   base64.StdEncoding.EncodeToString(doc),
+		NonceHex:      hex.EncodeToString(nonce),
+		Repo:          repo,
+	}
+	out, code := Run(StageVerify, in) // empty anchors => embedded production roots
+	if code != ExitAccepted || out.Outputs == nil {
+		reason := "unknown"
+		if out.Rejection != nil {
+			reason = out.Rejection.Code
+		}
+		t.Fatalf("live verification rejected (exit %d, %s); host=%s repo=%s", code, reason, host, repo)
+	}
+	t.Logf("accepted: code_digest=%s enclave=%s", out.Outputs.CodeDigest, out.Outputs.EnclaveMeasurement.Type)
+
+	// The same bytes must still verify with the clock pinned to now — the
+	// contract a frozen real-frozen fixture relies on, checked on live collateral.
+	in.VerificationTimeUnix = time.Now().Unix()
+	if _, code := Run(StageVerify, in); code != ExitAccepted {
+		t.Fatalf("pinned-time replay of the live document did not accept (exit %d)", code)
+	}
+}

--- a/verifier/conformance/testdata/envelope-malformed-json.json
+++ b/verifier/conformance/testdata/envelope-malformed-json.json
@@ -1,0 +1,11 @@
+{
+  "id": "envelope-malformed-json",
+  "stage": "verify-attestation-v3",
+  "input": {
+    "schema_version": "1",
+    "document_b64": "ew==",
+    "nonce_hex": "0000000000000000000000000000000000000000000000000000000000000000",
+    "repo": "tinfoilsh/confidential-inference-proxy"
+  },
+  "expected": { "accepted": false }
+}

--- a/verifier/conformance/testdata/envelope-not-json.json
+++ b/verifier/conformance/testdata/envelope-not-json.json
@@ -1,0 +1,11 @@
+{
+  "id": "envelope-not-json",
+  "stage": "v3-check-envelope",
+  "input": {
+    "schema_version": "1",
+    "document_b64": "aGVsbG8=",
+    "nonce_hex": "0000000000000000000000000000000000000000000000000000000000000000",
+    "repo": "tinfoilsh/confidential-inference-proxy"
+  },
+  "expected": { "accepted": false }
+}

--- a/verifier/quote/sev/authenticate.go
+++ b/verifier/quote/sev/authenticate.go
@@ -34,20 +34,30 @@ var askArkGenoaPEM []byte
 //go:embed turin_cert_chain.pem
 var askArkTurinPEM []byte
 
+// amdRootPEMOverride, when non-nil, replaces the embedded per-product anchor
+// and timeNow is the validity-window clock; production defaults, overridden
+// only by the conformance build (see conformance.go).
+var (
+	amdRootPEMOverride []byte
+	timeNow            = time.Now
+)
+
 // trustedRoots builds the pinned AMD trust anchors from repo-owned copies
 // rather than the library's embedded defaults, so an anchor only changes
 // when its file is deliberately regenerated. A fresh instance is built per
 // authentication: the library caches the CRL it fetched on this object, and
 // document-supplied collateral must never affect other verifications.
 func trustedRoots(productLine string) (map[string][]*trust.AMDRootCerts, error) {
-	var rootPEM []byte
-	switch productLine {
-	case ProductGenoa:
-		rootPEM = askArkGenoaPEM
-	case ProductTurin:
-		rootPEM = askArkTurinPEM
-	default:
-		return nil, fmt.Errorf("unsupported SEV product line %q", productLine)
+	rootPEM := amdRootPEMOverride
+	if rootPEM == nil {
+		switch productLine {
+		case ProductGenoa:
+			rootPEM = askArkGenoaPEM
+		case ProductTurin:
+			rootPEM = askArkTurinPEM
+		default:
+			return nil, fmt.Errorf("unsupported SEV product line %q", productLine)
+		}
 	}
 	roots := new(trust.AMDRootCerts)
 	if err := roots.FromKDSCertBytes(rootPEM); err != nil {
@@ -180,7 +190,7 @@ func Authenticate(doc *envelope.Document) (*Quote, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parsing amd-crl collateral: %w", err)
 	}
-	if now := time.Now(); now.Before(parsedCRL.ThisUpdate) || now.After(parsedCRL.NextUpdate) {
+	if now := timeNow(); now.Before(parsedCRL.ThisUpdate) || now.After(parsedCRL.NextUpdate) {
 		return nil, fmt.Errorf("amd-crl collateral is outside its validity window (this_update %s, next_update %s)",
 			parsedCRL.ThisUpdate.Format(time.RFC3339), parsedCRL.NextUpdate.Format(time.RFC3339))
 	}
@@ -254,7 +264,7 @@ func verifySignature(reportBase64 string, vcekDER, askDER, arkDER, crlDER []byte
 		CheckRevocations: true,
 		TrustedRoots:     roots,
 		Product:          product,
-		Now:              time.Now(),
+		Now:              timeNow(),
 	}
 
 	attestation := &sevsnp.Attestation{

--- a/verifier/quote/sev/conformance.go
+++ b/verifier/quote/sev/conformance.go
@@ -2,6 +2,10 @@
 
 package sev
 
+// The setters below mutate process-global seams and are not safe to call
+// while verifications run concurrently; the conformance adapter is
+// single-call by contract.
+
 import "time"
 
 // SetAMDRoot injects a trust anchor (ASK+ARK PEM) for authenticating synthetic

--- a/verifier/quote/sev/conformance.go
+++ b/verifier/quote/sev/conformance.go
@@ -1,0 +1,15 @@
+//go:build tinfoil_conformance
+
+package sev
+
+import "time"
+
+// SetAMDRoot injects a trust anchor (ASK+ARK PEM) for authenticating synthetic
+// reports; ResetAMDRoot restores the embedded Genoa root.
+func SetAMDRoot(pem []byte) { amdRootPEM = pem }
+func ResetAMDRoot()         { amdRootPEM = askArkGenoaPEM }
+
+// SetVerificationTime pins the validity-window clock so the harness can replay
+// a frozen document at its capture time; ResetVerificationTime restores time.Now.
+func SetVerificationTime(t time.Time) { timeNow = func() time.Time { return t } }
+func ResetVerificationTime()          { timeNow = time.Now }

--- a/verifier/quote/sev/conformance.go
+++ b/verifier/quote/sev/conformance.go
@@ -10,8 +10,8 @@ import "time"
 
 // SetAMDRoot injects a trust anchor (ASK+ARK PEM) for authenticating synthetic
 // reports; ResetAMDRoot restores the embedded Genoa root.
-func SetAMDRoot(pem []byte) { amdRootPEM = pem }
-func ResetAMDRoot()         { amdRootPEM = askArkGenoaPEM }
+func SetAMDRoot(pem []byte) { amdRootPEMOverride = pem }
+func ResetAMDRoot()         { amdRootPEMOverride = nil }
 
 // SetVerificationTime pins the validity-window clock so the harness can replay
 // a frozen document at its capture time; ResetVerificationTime restores time.Now.

--- a/verifier/quote/tdx/authenticate.go
+++ b/verifier/quote/tdx/authenticate.go
@@ -97,7 +97,7 @@ func Authenticate(doc *envelope.Document) (*Quote, error) {
 		TrustedRoots:     intelRootCertPool,
 		GetCollateral:    true,
 		CheckRevocations: true,
-		Now:              time.Now(),
+		Now:              timeNow(),
 	}
 	if err := tdxverify.TdxQuote(parsed, opts); err != nil {
 		return nil, fmt.Errorf("verifying TDX quote: %w", err)
@@ -178,7 +178,7 @@ func (g *pcsReplayGetter) Get(requestURL string) (map[string][]string, []byte, e
 	// CRL from a .der URL that does not identify the body as a CRL.
 	crl, crlErr := x509.ParseRevocationList(body)
 	if crlErr == nil {
-		if now := time.Now(); now.Before(crl.ThisUpdate) || now.After(crl.NextUpdate) {
+		if now := timeNow(); now.Before(crl.ThisUpdate) || now.After(crl.NextUpdate) {
 			return nil, nil, fmt.Errorf("captured CRL for %s is outside its validity window", requestURL)
 		}
 	} else if strings.Contains(key, "crl") {
@@ -256,6 +256,10 @@ func (r *tcbEvaluationRecorder) minimum() (int, error) {
 var sgxRootCACertPEM []byte
 
 var intelRootCertPool *x509.CertPool
+
+// timeNow is the validity-window clock; the production default, overridden only
+// by the conformance build to replay a frozen document at its capture time.
+var timeNow = time.Now
 
 func init() {
 	root, _ := pem.Decode(sgxRootCACertPEM)

--- a/verifier/quote/tdx/conformance.go
+++ b/verifier/quote/tdx/conformance.go
@@ -20,7 +20,13 @@ func SetIntelRoot(rootPEM []byte) error {
 	return nil
 }
 
-func ResetIntelRoot() { intelRootCertPool, _ = poolFromPEM(sgxRootCACertPEM) }
+func ResetIntelRoot() {
+	pool, err := poolFromPEM(sgxRootCACertPEM)
+	if err != nil {
+		panic("embedded Intel root failed to parse: " + err.Error()) // matches init()
+	}
+	intelRootCertPool = pool
+}
 
 func poolFromPEM(rootPEM []byte) (*x509.CertPool, error) {
 	block, _ := pem.Decode(rootPEM)

--- a/verifier/quote/tdx/conformance.go
+++ b/verifier/quote/tdx/conformance.go
@@ -1,0 +1,42 @@
+//go:build tinfoil_conformance
+
+package tdx
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"time"
+)
+
+// SetIntelRoot injects an Intel SGX root (PEM) for authenticating synthetic
+// quotes; ResetIntelRoot restores the embedded root.
+func SetIntelRoot(rootPEM []byte) error {
+	pool, err := poolFromPEM(rootPEM)
+	if err != nil {
+		return err
+	}
+	intelRootCertPool = pool
+	return nil
+}
+
+func ResetIntelRoot() { intelRootCertPool, _ = poolFromPEM(sgxRootCACertPEM) }
+
+func poolFromPEM(rootPEM []byte) (*x509.CertPool, error) {
+	block, _ := pem.Decode(rootPEM)
+	if block == nil {
+		return nil, fmt.Errorf("intel SGX root PEM carried no certificate")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(cert)
+	return pool, nil
+}
+
+// SetVerificationTime pins the validity-window clock so the harness can replay
+// a frozen document at its capture time; ResetVerificationTime restores time.Now.
+func SetVerificationTime(t time.Time) { timeNow = func() time.Time { return t } }
+func ResetVerificationTime()          { timeNow = time.Now }

--- a/verifier/quote/tdx/conformance.go
+++ b/verifier/quote/tdx/conformance.go
@@ -2,6 +2,10 @@
 
 package tdx
 
+// The setters below mutate process-global seams and are not safe to call
+// while verifications run concurrently; the conformance adapter is
+// single-call by contract.
+
 import (
 	"crypto/x509"
 	"encoding/pem"


### PR DESCRIPTION
Implements the harness using the new anchors for https://github.com/tinfoilsh/tinfoil-conformance/pull/13. Should be enough to be able to verify another sdk for almost identical behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a v3 conformance harness and CLI that run cross-SDK fixtures against the verifier and attribute failures by layer, plus a `live-verify` lane that exercises a live enclave through the public API; production behavior is unchanged behind the `tinfoil_conformance` build tag. The full `verify-attestation-v3` stage now rejects documents that endorse no TLS/HPKE channel keys (old: accepted) with ENVELOPE_REJECTED, and the adapter input requires `schema_version: "1"` and exactly one JSON value on stdin (trailing data is MALFORMED_INPUT, exit 30).

- Adds `cmd/tinfoil-conformance` with stages `verify-attestation-v3`, `v3-check-envelope`, `v3-authenticate-provenance`, `v3-assemble-policy`, `v3-authenticate-quote`, plus `capabilities`, `capture`, and `live-verify`; capabilities advertise `freshness_enforced: true` and `channel_binding: tls-spki`.
- `live-verify` verifies a live enclave through `client.VerifyDocumentV3` (embedded roots, current time, no seams) and requires the presented TLS SPKI fingerprint to equal the endorsed key.
- Implements `verifier/conformance`: composes envelope check → provenance (code + platform + freshness) → quote authenticate/assemble/validate; injects synthetic roots via tag-gated seams `sev.SetAMDRoot`, `tdx.SetIntelRoot`, and `provenance.NewClientFromJSON`; pins verification time with `SetVerificationTime`.
- Surfaces endorsed channel keys (`tls_public_key_fp`, `hpke_public_key`) in accept outputs and asserts declared facts so accepts are byte-identical across SDKs.
- The Turin `platform_info.iommu_write_safe` member now parses so Turin-policy artifacts stay readable, while a selected policy requiring it fails closed at assembly (bit 6 is reserved in the supported ABI model).
- Adds tag-gated seams only in `verifier/quote/sev` and `verifier/quote/tdx`; the harness tracks the current verifier signatures, threading register pinning, freshness max-age, and verification options as their defaults. No migration needed.

<sup>Written for commit 9551f4825c514cf08ae3d6231fe7ca59cb66b655. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-go/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

