### PR TITLE
Separate router configuration from verified EHBP state

### DIFF
--- a/ehbp_transport.go
+++ b/ehbp_transport.go
@@ -37,6 +37,7 @@ const (
 const (
 	defaultTransportMode = TransportEHBP
 	defaultConfigRepo    = "tinfoilsh/confidential-model-router"
+	defaultInferenceHost = "inference.tinfoil.sh"
 )
 
 type clientConfig struct {
@@ -120,6 +121,11 @@ func NewClientWithOptions(opts ...ClientOption) (*Client, error) {
 		if _, err := originOf(cfg.baseURL); err != nil {
 			return nil, fmt.Errorf("invalid base URL: %w", err)
 		}
+		resolvedEnclave, err := resolveEnclaveForBaseURL(cfg.baseURL, cfg.enclave)
+		if err != nil {
+			return nil, err
+		}
+		cfg.enclave = resolvedEnclave
 	}
 
 	var secureClient *client.SecureClient
@@ -141,6 +147,26 @@ func NewClientWithOptions(opts ...ClientOption) (*Client, error) {
 
 	return createClientFromSecureClient(secureClient, cfg.transport, cfg.baseURL,
 		resolveUserCacheSecret(cfg.userCacheSecret, cfg.userCacheSecretSet), cfg.openaiOpts...)
+}
+
+func resolveEnclaveForBaseURL(baseURL, enclave string) (string, error) {
+	origin, err := originOf(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid base URL: %w", err)
+	}
+	if origin != "https://"+defaultInferenceHost {
+		return enclave, nil
+	}
+	if enclave == "" {
+		// inference.tinfoil.sh is a stable enclave identity, not a
+		// router-forwarding proxy. Request its matching bundle instead of
+		// combining a random default-router key with this base URL.
+		return defaultInferenceHost, nil
+	}
+	if enclave != defaultInferenceHost {
+		return "", fmt.Errorf("base URL %q cannot route to enclave %q; use a proxy that forwards %s or connect directly", baseURL, enclave, enclaveURLHeader)
+	}
+	return enclave, nil
 }
 
 type verifiedTransport interface {

--- a/ehbp_transport.go
+++ b/ehbp_transport.go
@@ -292,18 +292,18 @@ func ehbpHTTPClient(secureClient *client.SecureClient, baseURL string) (*http.Cl
 	// rebuilds the transport with the then-current enclave, which keeps the
 	// header correct (including on the retry that follows a key rotation) without
 	// an unsynchronized read of the client's mutable state.
-	buildTransport := func(hpkePublicKeyHex string) (http.RoundTripper, error) {
-		inner, err := buildEHBPTransport(hpkePublicKeyHex)
+	buildTransport := func(verified *client.GroundTruth) (http.RoundTripper, error) {
+		inner, err := buildEHBPTransport(verified.HPKEPublicKey)
 		if err != nil {
 			return nil, err
 		}
 		if baseURL == "" {
 			// The OpenAI client keeps the base URL it received at construction.
-			// Route each direct request to the currently verified bundle domain so
-			// an ATC-driven endpoint/key rotation replaces the pair atomically.
-			return &directEnclaveTransport{enclave: secureClient, transport: inner}, nil
+			// Capture the verified endpoint with the transport's HPKE key so a
+			// concurrent later verification cannot split the route/key pair.
+			return &directEnclaveTransport{enclave: verified.EnclaveHost, transport: inner}, nil
 		}
-		if headerValue, ok := enclaveURLHeaderValue(baseURL, secureClient.Enclave()); ok {
+		if headerValue, ok := enclaveURLHeaderValue(baseURL, verified.EnclaveHost); ok {
 			return &enclaveURLHeaderTransport{
 				enclaveURL: headerValue,
 				transport:  inner,
@@ -312,7 +312,7 @@ func ehbpHTTPClient(secureClient *client.SecureClient, baseURL string) (*http.Cl
 		return inner, nil
 	}
 
-	inner, err := buildTransport(groundTruth.HPKEPublicKey)
+	inner, err := buildTransport(groundTruth)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -325,18 +325,17 @@ func ehbpHTTPClient(secureClient *client.SecureClient, baseURL string) (*http.Cl
 // verified state. The outer host-bound transport has already rejected any
 // caller-supplied foreign origin before this rewrite occurs.
 type directEnclaveTransport struct {
-	enclave   enclaveProvider
+	enclave   string
 	transport http.RoundTripper
 }
 
 func (t *directEnclaveTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	host := t.enclave.Enclave()
-	if host == "" {
+	if t.enclave == "" {
 		return nil, fmt.Errorf("verified enclave endpoint is empty")
 	}
 	req = req.Clone(req.Context())
 	req.URL.Scheme = "https"
-	req.URL.Host = host
+	req.URL.Host = t.enclave
 	return t.transport.RoundTrip(req)
 }
 
@@ -470,11 +469,11 @@ type ehbpReVerifyingTransport struct {
 	// reverify re-runs attestation and returns an EHBP transport built from the
 	// freshly attested HPKE key.
 	reverify              func() (http.RoundTripper, error)
-	build                 func(string) (http.RoundTripper, error)
+	build                 func(*client.GroundTruth) (http.RoundTripper, error)
 	documentAfterReverify func() *client.VerificationDocument
 }
 
-func newEHBPReVerifyingTransport(secureClient *client.SecureClient, inner http.RoundTripper, build func(hpkePublicKeyHex string) (http.RoundTripper, error)) *ehbpReVerifyingTransport {
+func newEHBPReVerifyingTransport(secureClient *client.SecureClient, inner http.RoundTripper, build func(*client.GroundTruth) (http.RoundTripper, error)) *ehbpReVerifyingTransport {
 	return &ehbpReVerifyingTransport{
 		secureClient:          secureClient,
 		transport:             inner,
@@ -486,7 +485,7 @@ func newEHBPReVerifyingTransport(secureClient *client.SecureClient, inner http.R
 			if err != nil {
 				return nil, err
 			}
-			return build(groundTruth.HPKEPublicKey)
+			return build(groundTruth)
 		},
 	}
 }
@@ -575,7 +574,7 @@ func (t *ehbpReVerifyingTransport) verifyAndReplace() (*client.GroundTruth, erro
 	if err != nil {
 		return nil, err
 	}
-	newTransport, err := t.build(groundTruth.HPKEPublicKey)
+	newTransport, err := t.build(groundTruth)
 	if err != nil {
 		return nil, err
 	}

--- a/ehbp_transport.go
+++ b/ehbp_transport.go
@@ -163,10 +163,10 @@ func resolveEnclaveForBaseURL(baseURL, enclave string) (string, error) {
 		// combining a random default-router key with this base URL.
 		return defaultInferenceHost, nil
 	}
-	if enclave != defaultInferenceHost {
+	if !strings.EqualFold(enclave, defaultInferenceHost) {
 		return "", fmt.Errorf("base URL %q cannot route to enclave %q; use a proxy that forwards %s or connect directly", baseURL, enclave, enclaveURLHeader)
 	}
-	return enclave, nil
+	return defaultInferenceHost, nil
 }
 
 type verifiedTransport interface {

--- a/ehbp_transport.go
+++ b/ehbp_transport.go
@@ -37,7 +37,6 @@ const (
 const (
 	defaultTransportMode = TransportEHBP
 	defaultConfigRepo    = "tinfoilsh/confidential-model-router"
-	defaultInferenceHost = "inference.tinfoil.sh"
 )
 
 type clientConfig struct {
@@ -121,11 +120,6 @@ func NewClientWithOptions(opts ...ClientOption) (*Client, error) {
 		if _, err := originOf(cfg.baseURL); err != nil {
 			return nil, fmt.Errorf("invalid base URL: %w", err)
 		}
-		resolvedEnclave, err := resolveEnclaveForBaseURL(cfg.baseURL, cfg.enclave)
-		if err != nil {
-			return nil, err
-		}
-		cfg.enclave = resolvedEnclave
 	}
 
 	var secureClient *client.SecureClient
@@ -147,26 +141,6 @@ func NewClientWithOptions(opts ...ClientOption) (*Client, error) {
 
 	return createClientFromSecureClient(secureClient, cfg.transport, cfg.baseURL,
 		resolveUserCacheSecret(cfg.userCacheSecret, cfg.userCacheSecretSet), cfg.openaiOpts...)
-}
-
-func resolveEnclaveForBaseURL(baseURL, enclave string) (string, error) {
-	origin, err := originOf(baseURL)
-	if err != nil {
-		return "", fmt.Errorf("invalid base URL: %w", err)
-	}
-	if origin != "https://"+defaultInferenceHost {
-		return enclave, nil
-	}
-	if enclave == "" {
-		// inference.tinfoil.sh is a stable enclave identity, not a
-		// router-forwarding proxy. Request its matching bundle instead of
-		// combining a random default-router key with this base URL.
-		return defaultInferenceHost, nil
-	}
-	if !strings.EqualFold(enclave, defaultInferenceHost) {
-		return "", fmt.Errorf("base URL %q cannot route to enclave %q; use a proxy that forwards %s or connect directly", baseURL, enclave, enclaveURLHeader)
-	}
-	return defaultInferenceHost, nil
 }
 
 type verifiedTransport interface {
@@ -222,7 +196,7 @@ func secureHTTPClient(secureClient *client.SecureClient, mode TransportMode, bas
 	}
 	httpClient.Transport = &hostBoundRoundTripper{
 		allowedOrigins: origins,
-		enclave:        secureClient.Enclave(),
+		enclave:        secureClient,
 		transport:      transport,
 	}
 	return &securedHTTPClient{
@@ -258,16 +232,25 @@ func allowedOrigins(enclave, baseURL string) (map[string]struct{}, error) {
 // API key, to an arbitrary host.
 type hostBoundRoundTripper struct {
 	allowedOrigins map[string]struct{}
-	enclave        string
+	enclave        enclaveProvider
 	transport      http.RoundTripper
 }
 
 func (t *hostBoundRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	origin := normalizedOrigin(req.URL)
-	if _, ok := t.allowedOrigins[origin]; !ok {
-		return nil, fmt.Errorf("refusing to send request to %q: client is bound to enclave %q", origin, t.enclave)
+	_, staticallyAllowed := t.allowedOrigins[origin]
+	currentOrigin, err := originOf("https://" + t.enclave.Enclave())
+	if err != nil {
+		return nil, fmt.Errorf("invalid verified enclave: %w", err)
+	}
+	if !staticallyAllowed && origin != currentOrigin {
+		return nil, fmt.Errorf("refusing to send request to %q: client is bound to enclave %q", origin, t.enclave.Enclave())
 	}
 	return t.transport.RoundTrip(req)
+}
+
+type enclaveProvider interface {
+	Enclave() string
 }
 
 // tlsPinnedHTTPClient returns the enclave-pinned HTTP client that re-verifies
@@ -314,6 +297,12 @@ func ehbpHTTPClient(secureClient *client.SecureClient, baseURL string) (*http.Cl
 		if err != nil {
 			return nil, err
 		}
+		if baseURL == "" {
+			// The OpenAI client keeps the base URL it received at construction.
+			// Route each direct request to the currently verified bundle domain so
+			// an ATC-driven endpoint/key rotation replaces the pair atomically.
+			return &directEnclaveTransport{enclave: secureClient, transport: inner}, nil
+		}
 		if headerValue, ok := enclaveURLHeaderValue(baseURL, secureClient.Enclave()); ok {
 			return &enclaveURLHeaderTransport{
 				enclaveURL: headerValue,
@@ -330,6 +319,25 @@ func ehbpHTTPClient(secureClient *client.SecureClient, baseURL string) (*http.Cl
 
 	transport := newEHBPReVerifyingTransport(secureClient, inner, buildTransport)
 	return &http.Client{Transport: transport}, transport, nil
+}
+
+// directEnclaveTransport routes a request to the endpoint in the active
+// verified state. The outer host-bound transport has already rejected any
+// caller-supplied foreign origin before this rewrite occurs.
+type directEnclaveTransport struct {
+	enclave   enclaveProvider
+	transport http.RoundTripper
+}
+
+func (t *directEnclaveTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	host := t.enclave.Enclave()
+	if host == "" {
+		return nil, fmt.Errorf("verified enclave endpoint is empty")
+	}
+	req = req.Clone(req.Context())
+	req.URL.Scheme = "https"
+	req.URL.Host = host
+	return t.transport.RoundTrip(req)
 }
 
 // enclaveURLHeaderValue returns the X-Tinfoil-Enclave-Url header value and

--- a/ehbp_transport_test.go
+++ b/ehbp_transport_test.go
@@ -264,7 +264,7 @@ func TestDirectEnclaveTransportKeepsEndpointPairedWithTransportKey(t *testing.T)
 		return newResponse(http.StatusOK, "ok"), nil
 	})
 	rt := &directEnclaveTransport{enclave: "old.example.com", transport: inner}
-	req, err := http.NewRequest(http.MethodGet, "https://old.example.com/v1/models", nil)
+	req, err := http.NewRequest(http.MethodGet, "https://api.openai.com/v1/models", nil)
 	require.NoError(t, err)
 
 	_, err = rt.RoundTrip(req)
@@ -273,7 +273,7 @@ func TestDirectEnclaveTransportKeepsEndpointPairedWithTransportKey(t *testing.T)
 	require.NoError(t, err)
 
 	require.Equal(t, []string{"old.example.com", "old.example.com"}, seen)
-	require.Equal(t, "old.example.com", req.URL.Host, "routing must not mutate the caller's request")
+	require.Equal(t, "api.openai.com", req.URL.Host, "routing must not mutate the caller's request")
 }
 
 func TestHostBoundRoundTripperAllowsNewlyVerifiedEndpoint(t *testing.T) {

--- a/ehbp_transport_test.go
+++ b/ehbp_transport_test.go
@@ -257,24 +257,22 @@ func TestHostBoundRoundTripperRejectsForeignHostAndScheme(t *testing.T) {
 	require.Contains(t, err.Error(), "ftp://enclave.example.com")
 }
 
-func TestDirectEnclaveTransportFollowsVerifiedEndpointRotation(t *testing.T) {
-	endpoint := &mutableEnclave{host: "old.example.com"}
+func TestDirectEnclaveTransportKeepsEndpointPairedWithTransportKey(t *testing.T) {
 	var seen []string
 	inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		seen = append(seen, req.URL.Host)
 		return newResponse(http.StatusOK, "ok"), nil
 	})
-	rt := &directEnclaveTransport{enclave: endpoint, transport: inner}
+	rt := &directEnclaveTransport{enclave: "old.example.com", transport: inner}
 	req, err := http.NewRequest(http.MethodGet, "https://old.example.com/v1/models", nil)
 	require.NoError(t, err)
 
 	_, err = rt.RoundTrip(req)
 	require.NoError(t, err)
-	endpoint.host = "new.example.com"
 	_, err = rt.RoundTrip(req)
 	require.NoError(t, err)
 
-	require.Equal(t, []string{"old.example.com", "new.example.com"}, seen)
+	require.Equal(t, []string{"old.example.com", "old.example.com"}, seen)
 	require.Equal(t, "old.example.com", req.URL.Host, "routing must not mutate the caller's request")
 }
 

--- a/ehbp_transport_test.go
+++ b/ehbp_transport_test.go
@@ -24,6 +24,12 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
+type mutableEnclave struct {
+	host string
+}
+
+func (e *mutableEnclave) Enclave() string { return e.host }
+
 func newResponse(status int, body string) *http.Response {
 	return &http.Response{
 		StatusCode: status,
@@ -66,36 +72,6 @@ func TestProxyClientOptionsApply(t *testing.T) {
 	require.Equal(t, "https://proxy.example.com/", cfg.baseURL)
 	require.True(t, cfg.baseURLSet)
 	require.Equal(t, "https://proxy.example.com", cfg.attestationBundleURL)
-}
-
-func TestResolveEnclaveForBaseURL(t *testing.T) {
-	tests := []struct {
-		name    string
-		baseURL string
-		enclave string
-		want    string
-		wantErr string
-	}{
-		{name: "official inference defaults to matching enclave", baseURL: "https://inference.tinfoil.sh/v1/", want: defaultInferenceHost},
-		{name: "official inference accepts matching enclave", baseURL: "https://INFERENCE.TINFOIL.SH:443/v1/", enclave: defaultInferenceHost, want: defaultInferenceHost},
-		{name: "official inference canonicalizes matching enclave case", baseURL: "https://inference.tinfoil.sh/v1/", enclave: "INFERENCE.TINFOIL.SH", want: defaultInferenceHost},
-		{name: "official inference rejects another enclave", baseURL: "https://inference.tinfoil.sh/v1/", enclave: "router.inf6.tinfoil.sh", wantErr: "cannot route"},
-		{name: "custom proxy preserves automatic selection", baseURL: "https://proxy.example.com/v1/", want: ""},
-		{name: "custom proxy preserves configured enclave", baseURL: "https://proxy.example.com/v1/", enclave: "router.example.com", want: "router.example.com"},
-		{name: "plaintext inference is not the official secure endpoint", baseURL: "http://inference.tinfoil.sh/v1/", want: ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := resolveEnclaveForBaseURL(tt.baseURL, tt.enclave)
-			if tt.wantErr != "" {
-				require.ErrorContains(t, err, tt.wantErr)
-				return
-			}
-			require.NoError(t, err)
-			require.Equal(t, tt.want, got)
-		})
-	}
 }
 
 func TestNewClientWithOptionsRejectsInvalidBaseURL(t *testing.T) {
@@ -236,7 +212,7 @@ func TestHostBoundRoundTripperAllowsEnclaveAndProxy(t *testing.T) {
 		calls++
 		return newResponse(http.StatusOK, "ok"), nil
 	})
-	rt := &hostBoundRoundTripper{allowedOrigins: origins, enclave: "enclave.example.com", transport: inner}
+	rt := &hostBoundRoundTripper{allowedOrigins: origins, enclave: &mutableEnclave{host: "enclave.example.com"}, transport: inner}
 
 	for _, target := range []string{
 		"https://enclave.example.com/v1/models",
@@ -260,7 +236,7 @@ func TestHostBoundRoundTripperRejectsForeignHostAndScheme(t *testing.T) {
 		t.Fatalf("inner transport must not be called for a rejected request")
 		return nil, nil
 	})
-	rt := &hostBoundRoundTripper{allowedOrigins: origins, enclave: "enclave.example.com", transport: inner}
+	rt := &hostBoundRoundTripper{allowedOrigins: origins, enclave: &mutableEnclave{host: "enclave.example.com"}, transport: inner}
 
 	foreign, err := http.NewRequest(http.MethodGet, "https://evil.example.com/v1/models", nil)
 	require.NoError(t, err)
@@ -279,6 +255,49 @@ func TestHostBoundRoundTripperRejectsForeignHostAndScheme(t *testing.T) {
 	_, err = rt.RoundTrip(unsupported)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "ftp://enclave.example.com")
+}
+
+func TestDirectEnclaveTransportFollowsVerifiedEndpointRotation(t *testing.T) {
+	endpoint := &mutableEnclave{host: "old.example.com"}
+	var seen []string
+	inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		seen = append(seen, req.URL.Host)
+		return newResponse(http.StatusOK, "ok"), nil
+	})
+	rt := &directEnclaveTransport{enclave: endpoint, transport: inner}
+	req, err := http.NewRequest(http.MethodGet, "https://old.example.com/v1/models", nil)
+	require.NoError(t, err)
+
+	_, err = rt.RoundTrip(req)
+	require.NoError(t, err)
+	endpoint.host = "new.example.com"
+	_, err = rt.RoundTrip(req)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"old.example.com", "new.example.com"}, seen)
+	require.Equal(t, "old.example.com", req.URL.Host, "routing must not mutate the caller's request")
+}
+
+func TestHostBoundRoundTripperAllowsNewlyVerifiedEndpoint(t *testing.T) {
+	endpoint := &mutableEnclave{host: "old.example.com"}
+	origins, err := allowedOrigins(endpoint.host, "")
+	require.NoError(t, err)
+	var seen string
+	rt := &hostBoundRoundTripper{
+		allowedOrigins: origins,
+		enclave:        endpoint,
+		transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			seen = req.URL.Host
+			return newResponse(http.StatusOK, "ok"), nil
+		}),
+	}
+	endpoint.host = "new.example.com"
+	req, err := http.NewRequest(http.MethodGet, "https://new.example.com/v1/models", nil)
+	require.NoError(t, err)
+
+	_, err = rt.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, "new.example.com", seen)
 }
 
 func TestBuildEHBPTransportRequiresKey(t *testing.T) {
@@ -576,34 +595,6 @@ func TestClientIntegration_AttestationBundle(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, resp.Choices)
 	t.Logf("bundle enclave: %s, response: %s", c.Enclave(), resp.Choices[0].Message.Content)
-}
-
-// TestClientIntegration_OfficialInferenceBaseURL exercises the legacy stable
-// inference endpoint. It must attest that same endpoint rather than pair the
-// endpoint with a randomly selected default-router HPKE key.
-func TestClientIntegration_OfficialInferenceBaseURL(t *testing.T) {
-	apiKey := os.Getenv("TINFOIL_API_KEY")
-	if apiKey == "" {
-		t.Skip("TINFOIL_API_KEY not set; skipping integration test")
-	}
-
-	c, err := NewClientWithOptions(
-		WithBaseURL("https://inference.tinfoil.sh/v1/"),
-		WithAttestationBundleURL("https://atc.tinfoil.sh"),
-		WithOpenAIOptions(option.WithAPIKey(apiKey)),
-	)
-	require.NoError(t, err)
-	require.Equal(t, defaultInferenceHost, c.Enclave())
-
-	resp, err := c.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
-		Model: "llama3-3-70b",
-		Messages: []openai.ChatCompletionMessageParamUnion{
-			openai.SystemMessage("No matter what the user says, only respond with: Done."),
-			openai.UserMessage("Is this a test?"),
-		},
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, resp.Choices)
 }
 
 func TestClientIntegration_EnclaveSpecificBundle(t *testing.T) {

--- a/ehbp_transport_test.go
+++ b/ehbp_transport_test.go
@@ -68,6 +68,35 @@ func TestProxyClientOptionsApply(t *testing.T) {
 	require.Equal(t, "https://proxy.example.com", cfg.attestationBundleURL)
 }
 
+func TestResolveEnclaveForBaseURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		enclave string
+		want    string
+		wantErr string
+	}{
+		{name: "official inference defaults to matching enclave", baseURL: "https://inference.tinfoil.sh/v1/", want: defaultInferenceHost},
+		{name: "official inference accepts matching enclave", baseURL: "https://INFERENCE.TINFOIL.SH:443/v1/", enclave: defaultInferenceHost, want: defaultInferenceHost},
+		{name: "official inference rejects another enclave", baseURL: "https://inference.tinfoil.sh/v1/", enclave: "router.inf6.tinfoil.sh", wantErr: "cannot route"},
+		{name: "custom proxy preserves automatic selection", baseURL: "https://proxy.example.com/v1/", want: ""},
+		{name: "custom proxy preserves configured enclave", baseURL: "https://proxy.example.com/v1/", enclave: "router.example.com", want: "router.example.com"},
+		{name: "plaintext inference is not the official secure endpoint", baseURL: "http://inference.tinfoil.sh/v1/", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveEnclaveForBaseURL(tt.baseURL, tt.enclave)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestNewClientWithOptionsRejectsInvalidBaseURL(t *testing.T) {
 	for _, baseURL := range []string{"", "proxy.example.com", "ftp://proxy.example.com", "://"} {
 		t.Run(baseURL, func(t *testing.T) {
@@ -546,6 +575,34 @@ func TestClientIntegration_AttestationBundle(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, resp.Choices)
 	t.Logf("bundle enclave: %s, response: %s", c.Enclave(), resp.Choices[0].Message.Content)
+}
+
+// TestClientIntegration_OfficialInferenceBaseURL exercises the legacy stable
+// inference endpoint. It must attest that same endpoint rather than pair the
+// endpoint with a randomly selected default-router HPKE key.
+func TestClientIntegration_OfficialInferenceBaseURL(t *testing.T) {
+	apiKey := os.Getenv("TINFOIL_API_KEY")
+	if apiKey == "" {
+		t.Skip("TINFOIL_API_KEY not set; skipping integration test")
+	}
+
+	c, err := NewClientWithOptions(
+		WithBaseURL("https://inference.tinfoil.sh/v1/"),
+		WithAttestationBundleURL("https://atc.tinfoil.sh"),
+		WithOpenAIOptions(option.WithAPIKey(apiKey)),
+	)
+	require.NoError(t, err)
+	require.Equal(t, defaultInferenceHost, c.Enclave())
+
+	resp, err := c.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
+		Model: "llama3-3-70b",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.SystemMessage("No matter what the user says, only respond with: Done."),
+			openai.UserMessage("Is this a test?"),
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Choices)
 }
 
 func TestClientIntegration_EnclaveSpecificBundle(t *testing.T) {

--- a/ehbp_transport_test.go
+++ b/ehbp_transport_test.go
@@ -78,6 +78,7 @@ func TestResolveEnclaveForBaseURL(t *testing.T) {
 	}{
 		{name: "official inference defaults to matching enclave", baseURL: "https://inference.tinfoil.sh/v1/", want: defaultInferenceHost},
 		{name: "official inference accepts matching enclave", baseURL: "https://INFERENCE.TINFOIL.SH:443/v1/", enclave: defaultInferenceHost, want: defaultInferenceHost},
+		{name: "official inference canonicalizes matching enclave case", baseURL: "https://inference.tinfoil.sh/v1/", enclave: "INFERENCE.TINFOIL.SH", want: defaultInferenceHost},
 		{name: "official inference rejects another enclave", baseURL: "https://inference.tinfoil.sh/v1/", enclave: "router.inf6.tinfoil.sh", wantErr: "cannot route"},
 		{name: "custom proxy preserves automatic selection", baseURL: "https://proxy.example.com/v1/", want: ""},
 		{name: "custom proxy preserves configured enclave", baseURL: "https://proxy.example.com/v1/", enclave: "router.example.com", want: "router.example.com"},

--- a/tinfoil_client.go
+++ b/tinfoil_client.go
@@ -90,7 +90,7 @@ type Client struct {
 	*openai.Client
 	secureClient      *client.SecureClient
 	httpClient        *http.Client
-	enclave, repo     string
+	repo              string
 	transport         TransportMode
 	verifiedTransport verifiedTransport
 }
@@ -136,7 +136,6 @@ func createClientFromSecureClient(secureClient *client.SecureClient, mode Transp
 		Client:            &openaiClient,
 		secureClient:      secureClient,
 		httpClient:        httpClient,
-		enclave:           secureClient.Enclave(),
 		repo:              secureClient.Repo(),
 		transport:         mode,
 		verifiedTransport: securedClient.transport,
@@ -144,7 +143,7 @@ func createClientFromSecureClient(secureClient *client.SecureClient, mode Transp
 }
 
 func (c *Client) Enclave() string {
-	return c.enclave
+	return c.secureClient.Enclave()
 }
 
 func (c *Client) Repo() string {

--- a/verifier/client/client.go
+++ b/verifier/client/client.go
@@ -43,7 +43,11 @@ type GroundTruth struct {
 }
 
 type SecureClient struct {
-	enclave, repo string
+	// enclave is the currently verified endpoint. It may change when the client
+	// discovers routers through an attestation bundle. configuredEnclave is the
+	// immutable caller-provided endpoint; an empty value means bundle-driven
+	// discovery and allows recovery to select a fresh router.
+	enclave, configuredEnclave, repo string
 
 	// When set, Verify fetches a pre-assembled attestation bundle from
 	// {attestationBundleURL}/attestation and verifies it client-side instead of
@@ -88,8 +92,9 @@ func fetchRouters() ([]string, error) {
 // NewSecureClient creates a new secure client with a given repo and enclave
 func NewSecureClient(enclave, repo string) *SecureClient {
 	return &SecureClient{
-		enclave: enclave,
-		repo:    repo,
+		enclave:           enclave,
+		configuredEnclave: enclave,
+		repo:              repo,
 	}
 }
 
@@ -97,6 +102,7 @@ func NewSecureClient(enclave, repo string) *SecureClient {
 func NewPinnedSecureClient(enclave string, codeMeasurement *attestation.Measurement, hardwareMeasurements []*attestation.HardwareMeasurement) *SecureClient {
 	return &SecureClient{
 		enclave:              enclave,
+		configuredEnclave:    enclave,
 		repo:                 pinnedNoRepo,
 		codeMeasurement:      codeMeasurement,
 		hardwareMeasurements: hardwareMeasurements,
@@ -205,16 +211,12 @@ func (s *SecureClient) Verify() (*GroundTruth, error) {
 		if s.codeMeasurement != nil {
 			return nil, fmt.Errorf("cannot combine a pinned measurement with an attestation bundle URL")
 		}
-		// Ask the bundle service for an enclave/repo-specific bundle when either
-		// is set; otherwise fetch the default router bundle.
-		enclaveURL := ""
-		if s.enclave != "" {
-			enclaveURL = "https://" + s.enclave
-		}
-		repo := ""
-		if s.repo != defaultRouterRepo {
-			repo = s.repo
-		}
+		// Ask the bundle service for the caller-configured enclave when one was
+		// supplied. Do not reuse an endpoint discovered from a previous default
+		// bundle: after an HPKE mismatch, recovery must be able to fetch a fresh
+		// default bundle and rotate the entire endpoint/key pair, matching the JS
+		// SDK's reset semantics.
+		enclaveURL, repo := s.bundleRequestParameters()
 		bundle, err := attestation.FetchBundleFor(s.attestationBundleURL, enclaveURL, repo)
 		if err != nil {
 			return nil, fmt.Errorf("fetchBundle: failed to fetch attestation bundle: %v", err)
@@ -316,6 +318,20 @@ func (s *SecureClient) Verify() (*GroundTruth, error) {
 	return groundTruth, nil
 }
 
+// bundleRequestParameters returns only caller-provided routing constraints.
+// In particular, it never turns an enclave discovered from a default bundle
+// into a pinned request parameter: recovery must remain free to select a fresh
+// default router and its matching HPKE key.
+func (s *SecureClient) bundleRequestParameters() (enclaveURL, repo string) {
+	if s.configuredEnclave != "" {
+		enclaveURL = "https://" + s.configuredEnclave
+	}
+	if s.repo != defaultRouterRepo {
+		repo = s.repo
+	}
+	return enclaveURL, repo
+}
+
 // VerifyFromBundle verifies using a pre-fetched attestation bundle (single-request verification)
 func (s *SecureClient) VerifyFromBundle(bundle *attestation.Bundle) (*GroundTruth, error) {
 	s.verifyMu.Lock()
@@ -402,8 +418,8 @@ func (s *SecureClient) verifyFromBundle(bundle *attestation.Bundle) (*GroundTrut
 }
 
 func (s *SecureClient) validateBundleDomain(domain string) error {
-	if groundTruth := s.GroundTruth(); groundTruth != nil && domain != groundTruth.EnclaveHost {
-		return fmt.Errorf("verifyBundle: domain %q does not match verified enclave %q", domain, groundTruth.EnclaveHost)
+	if s.configuredEnclave != "" && domain != s.configuredEnclave {
+		return fmt.Errorf("verifyBundle: domain %q does not match configured enclave %q", domain, s.configuredEnclave)
 	}
 	return nil
 }
@@ -509,11 +525,8 @@ func VerifyJSON(enclave, repo string, sigstoreTrustedRootJSON []byte) (string, e
 		return "", fmt.Errorf("failed to create sigstore client: %v", err)
 	}
 
-	client := &SecureClient{
-		enclave:        enclave,
-		repo:           repo,
-		sigstoreClient: sigstoreClient,
-	}
+	client := NewSecureClient(enclave, repo)
+	client.sigstoreClient = sigstoreClient
 	_, err = client.Verify()
 	if err != nil {
 		return "", err
@@ -545,11 +558,8 @@ func verifyBundle(bundle *attestation.Bundle, repo string, sigstoreTrustedRootJS
 		return "", fmt.Errorf("failed to create sigstore client: %v", err)
 	}
 
-	client := &SecureClient{
-		enclave:        bundle.Domain,
-		repo:           repo,
-		sigstoreClient: sigstoreClient,
-	}
+	client := NewSecureClient(bundle.Domain, repo)
+	client.sigstoreClient = sigstoreClient
 	_, err = client.VerifyFromBundle(bundle)
 	if err != nil {
 		return "", err

--- a/verifier/client/client.go
+++ b/verifier/client/client.go
@@ -42,12 +42,17 @@ type GroundTruth struct {
 	DigestFetched       bool                             `json:"-"`
 }
 
+type secureClientConfig struct {
+	// enclave is an optional caller constraint. An empty value delegates router
+	// selection to the attestation bundle service.
+	enclave string
+	repo    string
+}
+
 type SecureClient struct {
-	// enclave is the currently verified endpoint. It may change when the client
-	// discovers routers through an attestation bundle. configuredEnclave is the
-	// immutable caller-provided endpoint; an empty value means bundle-driven
-	// discovery and allows recovery to select a fresh router.
-	enclave, configuredEnclave, repo string
+	// config is immutable caller intent. The selected/verified endpoint lives in
+	// groundTruth, so discovery never overwrites configuration.
+	config secureClientConfig
 
 	// When set, Verify fetches a pre-assembled attestation bundle from
 	// {attestationBundleURL}/attestation and verifies it client-side instead of
@@ -71,10 +76,6 @@ var (
 	defaultRouterURL  = "https://atc.tinfoil.sh/routers"
 )
 
-func newFallbackClient() *SecureClient {
-	return NewSecureClient("inference.tinfoil.sh", defaultRouterRepo)
-}
-
 func fetchRouters() ([]string, error) {
 	resp, _, err := util.Get(defaultRouterURL)
 	if err != nil {
@@ -92,57 +93,57 @@ func fetchRouters() ([]string, error) {
 // NewSecureClient creates a new secure client with a given repo and enclave
 func NewSecureClient(enclave, repo string) *SecureClient {
 	return &SecureClient{
-		enclave:           enclave,
-		configuredEnclave: enclave,
-		repo:              repo,
+		config: secureClientConfig{enclave: enclave, repo: repo},
 	}
 }
 
 // NewPinnedSecureClient creates a new secure client with a given enclave and fixed measurements
 func NewPinnedSecureClient(enclave string, codeMeasurement *attestation.Measurement, hardwareMeasurements []*attestation.HardwareMeasurement) *SecureClient {
 	return &SecureClient{
-		enclave:              enclave,
-		configuredEnclave:    enclave,
-		repo:                 pinnedNoRepo,
+		config:               secureClientConfig{enclave: enclave, repo: pinnedNoRepo},
 		codeMeasurement:      codeMeasurement,
 		hardwareMeasurements: hardwareMeasurements,
 	}
 }
 
-// NewDefaultClient creates a new secure client with fallback mechanism.
-// It tries to fetch routers from the router service, attempts to verify each one,
-// and falls back to inference.tinfoil.sh if all routers fail.
+// NewDefaultClient asks ATC for eligible routers and returns the first one that
+// passes verification. Discovery fails closed: the SDK never substitutes a
+// hard-coded router when ATC is unavailable or all advertised routers fail.
 func NewDefaultClient() (*SecureClient, error) {
 	routers, err := fetchRouters()
 	if err != nil {
-		// If we can't get routers, fall back to inference.tinfoil.sh immediately
-		return newFallbackClient(), nil
+		return nil, fmt.Errorf("fetch routers from ATC: %w", err)
 	}
 
-	// Try each router in sequence
+	var lastErr error
 	for _, routerURL := range routers {
 		client := NewSecureClient(routerURL, defaultRouterRepo)
-
-		// Return first working router
-		_, err := client.Verify()
+		_, err = client.Verify()
 		if err == nil {
 			return client, nil
 		}
+		lastErr = err
 	}
 
-	return newFallbackClient(), nil
+	if lastErr != nil {
+		return nil, fmt.Errorf("no ATC router passed verification: %w", lastErr)
+	}
+	return nil, fmt.Errorf("ATC returned no routers")
 }
 
 // Enclave returns the enclave URL
 func (s *SecureClient) Enclave() string {
 	s.stateMu.RLock()
 	defer s.stateMu.RUnlock()
-	return s.enclave
+	if s.groundTruth != nil && s.groundTruth.EnclaveHost != "" {
+		return s.groundTruth.EnclaveHost
+	}
+	return s.config.enclave
 }
 
 // Repo returns the repository URL
 func (s *SecureClient) Repo() string {
-	return s.repo
+	return s.config.repo
 }
 
 // SetAttestationBundleURL configures the client to fetch and verify a
@@ -228,7 +229,7 @@ func (s *SecureClient) Verify() (*GroundTruth, error) {
 	var digest = pinnedNoDigest
 	var releaseTag string
 	if s.codeMeasurement == nil {
-		release, err := github.FetchLatestRelease(s.repo)
+		release, err := github.FetchLatestRelease(s.config.repo)
 		if err != nil {
 			return nil, fmt.Errorf("fetchDigest: failed to fetch latest release: %v", err)
 		}
@@ -240,18 +241,18 @@ func (s *SecureClient) Verify() (*GroundTruth, error) {
 			return nil, fmt.Errorf("verifyCode: failed to create sigstore client: %v", err)
 		}
 
-		sigstoreBundle, err := github.FetchAttestationBundle(s.repo, digest)
+		sigstoreBundle, err := github.FetchAttestationBundle(s.config.repo, digest)
 		if err != nil {
 			return nil, fmt.Errorf("verifyCode: failed to fetch attestation bundle: %v", err)
 		}
 
-		codeMeasurement, err = sigstoreClient.VerifyAttestationForRelease(sigstoreBundle, s.repo, releaseTag, digest)
+		codeMeasurement, err = sigstoreClient.VerifyAttestationForRelease(sigstoreBundle, s.config.repo, releaseTag, digest)
 		if err != nil {
 			return nil, fmt.Errorf("verifyCode: failed to verify attested measurements: %v", err)
 		}
 	}
 
-	enclaveAttestation, err := attestation.Fetch(s.enclave)
+	enclaveAttestation, err := attestation.Fetch(s.config.enclave)
 	if err != nil {
 		return nil, fmt.Errorf("verifyEnclave: failed to fetch enclave measurements: %v", err)
 	}
@@ -281,7 +282,7 @@ func (s *SecureClient) Verify() (*GroundTruth, error) {
 		}
 	}
 
-	if err := enclaveValidPubKey(s.enclave, enclaveVerification); err != nil {
+	if err := enclaveValidPubKey(s.config.enclave, enclaveVerification); err != nil {
 		return nil, fmt.Errorf("validateTLS: %v", err)
 	}
 
@@ -299,8 +300,8 @@ func (s *SecureClient) Verify() (*GroundTruth, error) {
 	}
 
 	groundTruth := &GroundTruth{
-		ConfigRepo:          s.repo,
-		EnclaveHost:         s.enclave,
+		ConfigRepo:          s.config.repo,
+		EnclaveHost:         s.config.enclave,
 		ReleaseTag:          releaseTag,
 		TLSPublicKey:        enclaveVerification.TLSPublicKeyFP,
 		HPKEPublicKey:       enclaveVerification.HPKEPublicKey,
@@ -323,11 +324,11 @@ func (s *SecureClient) Verify() (*GroundTruth, error) {
 // into a pinned request parameter: recovery must remain free to select a fresh
 // default router and its matching HPKE key.
 func (s *SecureClient) bundleRequestParameters() (enclaveURL, repo string) {
-	if s.configuredEnclave != "" {
-		enclaveURL = "https://" + s.configuredEnclave
+	if s.config.enclave != "" {
+		enclaveURL = "https://" + s.config.enclave
 	}
-	if s.repo != defaultRouterRepo {
-		repo = s.repo
+	if s.config.repo != defaultRouterRepo {
+		repo = s.config.repo
 	}
 	return enclaveURL, repo
 }
@@ -352,10 +353,10 @@ func (s *SecureClient) verifyFromBundle(bundle *attestation.Bundle) (*GroundTrut
 	var codeMeasurement *attestation.Measurement
 	if bundle.ReleaseTag != "" {
 		codeMeasurement, err = sigstoreClient.VerifyAttestationForRelease(
-			bundle.SigstoreBundle, s.repo, bundle.ReleaseTag, bundle.Digest,
+			bundle.SigstoreBundle, s.config.repo, bundle.ReleaseTag, bundle.Digest,
 		)
 	} else {
-		codeMeasurement, err = sigstoreClient.VerifyAttestation(bundle.SigstoreBundle, s.repo, bundle.Digest)
+		codeMeasurement, err = sigstoreClient.VerifyAttestation(bundle.SigstoreBundle, s.config.repo, bundle.Digest)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("verifyCode: failed to verify attested measurements: %v", err)
@@ -400,7 +401,7 @@ func (s *SecureClient) verifyFromBundle(bundle *attestation.Bundle) (*GroundTrut
 	}
 
 	groundTruth := &GroundTruth{
-		ConfigRepo:         s.repo,
+		ConfigRepo:         s.config.repo,
 		EnclaveHost:        bundle.Domain,
 		ReleaseTag:         bundle.ReleaseTag,
 		TLSPublicKey:       enclaveVerification.TLSPublicKeyFP,
@@ -418,8 +419,8 @@ func (s *SecureClient) verifyFromBundle(bundle *attestation.Bundle) (*GroundTrut
 }
 
 func (s *SecureClient) validateBundleDomain(domain string) error {
-	if s.configuredEnclave != "" && domain != s.configuredEnclave {
-		return fmt.Errorf("verifyBundle: domain %q does not match configured enclave %q", domain, s.configuredEnclave)
+	if s.config.enclave != "" && domain != s.config.enclave {
+		return fmt.Errorf("verifyBundle: domain %q does not match configured enclave %q", domain, s.config.enclave)
 	}
 	return nil
 }
@@ -449,7 +450,7 @@ func (s *SecureClient) makeRequest(req *http.Request) (*Response, error) {
 	// If URL doesn't start with anything, assume it's a relative path and set the base URL
 	if req.URL.Host == "" {
 		req.URL.Scheme = "https"
-		req.URL.Host = s.enclave
+		req.URL.Host = s.Enclave()
 	}
 
 	// Request headers may carry the API key, so never send them over a plaintext

--- a/verifier/client/client_test.go
+++ b/verifier/client/client_test.go
@@ -134,21 +134,49 @@ func TestCurrentVerifierVersion(t *testing.T) {
 	}
 }
 
-func TestVerifyFromBundleRejectsVerifiedDomainMismatch(t *testing.T) {
-	client := NewSecureClient("verified.example", defaultRouterRepo)
-	client.setVerifiedState(&GroundTruth{EnclaveHost: "verified.example"})
+func TestVerifyFromBundleRejectsConfiguredDomainMismatch(t *testing.T) {
+	client := NewSecureClient("configured.example", defaultRouterRepo)
+	client.setVerifiedState(&GroundTruth{EnclaveHost: "configured.example"})
 
 	_, err := client.VerifyFromBundle(&attestation.Bundle{Domain: "other.example"})
 
-	assert.EqualError(t, err, `verifyBundle: domain "other.example" does not match verified enclave "verified.example"`)
-	assert.Equal(t, "verified.example", client.Enclave())
-	assert.Equal(t, "verified.example", client.GroundTruth().EnclaveHost)
+	assert.EqualError(t, err, `verifyBundle: domain "other.example" does not match configured enclave "configured.example"`)
+	assert.Equal(t, "configured.example", client.Enclave())
+	assert.Equal(t, "configured.example", client.GroundTruth().EnclaveHost)
 }
 
-func TestBundleDomainAllowsInitialDiscovery(t *testing.T) {
+func TestBundleDomainRejectsInitialConfiguredMismatch(t *testing.T) {
 	client := NewSecureClient("configured.example", defaultRouterRepo)
 
-	assert.NoError(t, client.validateBundleDomain("discovered.example"))
+	assert.EqualError(t, client.validateBundleDomain("discovered.example"),
+		`verifyBundle: domain "discovered.example" does not match configured enclave "configured.example"`)
+}
+
+func TestBundleDomainAllowsAutomaticRouterRotation(t *testing.T) {
+	client := NewSecureClient("", defaultRouterRepo)
+	client.setVerifiedState(&GroundTruth{EnclaveHost: "old-router.example"})
+
+	assert.NoError(t, client.validateBundleDomain("new-router.example"))
+}
+
+func TestAutomaticBundleRecoveryDoesNotPinDiscoveredRouter(t *testing.T) {
+	client := NewSecureClient("", defaultRouterRepo)
+	client.setVerifiedState(&GroundTruth{EnclaveHost: "old-router.example"})
+
+	enclaveURL, repo := client.bundleRequestParameters()
+
+	assert.Empty(t, enclaveURL)
+	assert.Empty(t, repo)
+}
+
+func TestConfiguredBundleRecoveryKeepsCallerConstraints(t *testing.T) {
+	client := NewSecureClient("configured.example", "owner/custom-router")
+	client.setVerifiedState(&GroundTruth{EnclaveHost: "configured.example"})
+
+	enclaveURL, repo := client.bundleRequestParameters()
+
+	assert.Equal(t, "https://configured.example", enclaveURL)
+	assert.Equal(t, "owner/custom-router", repo)
 }
 
 func TestNewDefaultSecureClient(t *testing.T) {

--- a/verifier/client/client_test.go
+++ b/verifier/client/client_test.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"runtime/debug"
 	"strings"
@@ -198,13 +200,21 @@ func TestClientFetchRouters(t *testing.T) {
 	assert.True(t, strings.HasSuffix(routers[0], ".tinfoil.sh"))
 }
 
-func TestClientDefaultClient(t *testing.T) {
-	defaultClient := newFallbackClient()
-	enclave := defaultClient.Enclave()
-	assert.NotEmpty(t, enclave)
+func TestNewDefaultClientFailsClosedWhenATCReturnsNoRouters(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
 
-	_, err := defaultClient.Verify()
-	assert.NoError(t, err)
+	originalRouterURL := defaultRouterURL
+	defaultRouterURL = server.URL
+	t.Cleanup(func() { defaultRouterURL = originalRouterURL })
+
+	secureClient, err := NewDefaultClient()
+
+	assert.Nil(t, secureClient)
+	assert.EqualError(t, err, "ATC returned no routers")
 }
 
 func TestVerifyFromBundle(t *testing.T) {

--- a/verifier/client/verification_document.go
+++ b/verifier/client/verification_document.go
@@ -152,9 +152,6 @@ func newVerificationDocument(groundTruth *GroundTruth) *VerificationDocument {
 func (s *SecureClient) setVerifiedState(groundTruth *GroundTruth) {
 	clonedGroundTruth := cloneGroundTruth(groundTruth)
 	s.stateMu.Lock()
-	if clonedGroundTruth.EnclaveHost != "" {
-		s.enclave = clonedGroundTruth.EnclaveHost
-	}
 	s.groundTruth = clonedGroundTruth
 	s.verificationDocument = newVerificationDocument(clonedGroundTruth)
 	s.stateMu.Unlock()


### PR DESCRIPTION
## Summary

- keep immutable caller constraints in a dedicated config object and keep the selected router only in verified ground truth
- remove every SDK special case for inference.tinfoil.sh
- let automatically selected clients refresh the complete attested endpoint and HPKE key pair
- capture each direct route and HPKE key in one immutable transport generation
- keep explicitly configured enclaves pinned and reject bundle-domain mismatches
- fail closed when ATC is unavailable, empty, or advertises no verifiable router

A caller-provided base URL is treated as a real forwarding proxy. Omitting it delegates direct router selection to ATC. Public constructor signatures are unchanged.

## Security

Retries remain limited to the protocol-defined EHBP key-configuration mismatch path. The replacement endpoint and key are installed only after full client-side bundle verification. Request origins remain bound to the configured proxy or currently verified enclave.

## Validation

- go test ./...
- go test -race ./...
- go vet ./...