### PR TITLE
fix: exclude internal mobile bindings

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -34,17 +34,26 @@ jobs:
         # whenever upstream bumped its golang.org/x dependencies past the
         # versions recorded in our go.sum.
         run: |
-          export PATH=$PATH:$(go env GOPATH)/bin
-          go install golang.org/x/mobile/cmd/gomobile
-          go install golang.org/x/mobile/cmd/gobind
+          GOPATH_BIN="$(go env GOPATH)/bin"
+          export PATH="$PATH:$GOPATH_BIN"
+          MOBILE_VERSION="$(go list -m -f '{{.Version}}' golang.org/x/mobile)"
+          go install "golang.org/x/mobile/cmd/gomobile@$MOBILE_VERSION"
+          go install "golang.org/x/mobile/cmd/gobind@$MOBILE_VERSION"
           gomobile init -v
 
       - name: Build XCFramework
         run: |
-          export PATH=$PATH:$(go env GOPATH)/bin
-          # verifier/policy is excluded: its API (multi-value returns) is not
-          # representable by gomobile and crashes gobind.
-          gomobile bind -v -target=ios,iossimulator,macos -o Tinfoil.xcframework $(go list ./... | grep -v -E "/examples/|/rootfetch|/verifier/policy" | xargs)
+          GOPATH_BIN="$(go env GOPATH)/bin"
+          export PATH="$PATH:$GOPATH_BIN"
+          # Bind only packages that form the mobile SDK surface. policy is not
+          # representable by gobind, while sigstore and util are internal
+          # implementation packages whose zero-argument constructors conflict
+          # with NSObject nullability in current Apple SDKs.
+          go list ./... | grep -v -E "/examples/|/rootfetch|/verifier/(policy|sigstore|util)$" | xargs gomobile bind -v -target=ios,iossimulator,macos -o Tinfoil.xcframework
+          if find Tinfoil.xcframework -type f \( -name 'Sigstore.objc.h' -o -name 'Util.objc.h' \) | grep -q .; then
+            echo "internal verifier headers unexpectedly exported" >&2
+            exit 1
+          fi
           zip -ry Tinfoil.xcframework.zip Tinfoil.xcframework
 
       - name: Generate checksum


### PR DESCRIPTION
## Summary
- exclude internal sigstore and util packages from the public gomobile XCFramework
- prevent generated zero-argument constructors from conflicting with NSObject nullability in current Apple SDKs
- install the exact x/mobile version selected by go.mod and fail release if internal headers reappear

## Testing
- `go test ./...`
- actionlint
- built iOS, iOS simulator, and macOS XCFramework with pinned gomobile
- verified Sigstore.objc.h and Util.objc.h are absent

## Release sequence
After merge, publish tinfoil-go `v0.15.1`; tinfoil-swift can then update its binary target and release `v0.7.2`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude internal verifier `sigstore` and `util` packages from the public iOS/macOS XCFramework and pin the mobile toolchain to `go.mod`’s `golang.org/x/mobile` version. Previously the XCFramework exported `Sigstore.objc.h` and `Util.objc.h`, whose zero-arg constructors conflicted with `NSObject` nullability; now we filter them out and fail the build if they reappear.

- CI installs `gomobile`/`gobind` at the exact `golang.org/x/mobile` version from `go.mod`.
- `gomobile bind` targets only the SDK surface; excludes `/examples`, `/rootfetch`, and `/verifier/(policy|sigstore|util)`.
- Adds a guard that errors if `Sigstore.objc.h` or `Util.objc.h` is present in the XCFramework.
- Still emits a single XCFramework for iOS, iOS Simulator, and macOS.

**Rollout**
- After merge, publish `tinfoil-go` v0.15.1.
- Then update `tinfoil-swift`’s binary target and release v0.7.2.

<sup>Written for commit d69e285bf82519d8da527c9deebd5b0930cf1908. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-go/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

